### PR TITLE
allow commonjs as configs

### DIFF
--- a/src/ESDocCLI.js
+++ b/src/ESDocCLI.js
@@ -77,11 +77,7 @@ export default class ESDocCLI {
    * @private
    */
   _createConfigFromJSONFile(configFilePath) {
-    configFilePath = path.resolve(configFilePath);
-    let configJSON = fs.readFileSync(configFilePath, {encode: 'utf8'});
-    let config = JSON.parse(configJSON);
-
-    return config;
+    return require(path.resolve(configFilePath));
   }
 }
 


### PR DESCRIPTION
Hi! 
I suggest 'requiring' esdoc configuration via nodejs instead of manually parsing like it is done in webpack. This provides opportunity to specify some values in config dinamically, do some processing etc.
For example I have 'includes' and 'excludes' values configured in my build system, and i want these values imported to esdoc config.
This change does not break current json-format configurations as nodejs supports 'requiring' json out of the box as well as commonjs.