### PR TITLE
Fix crashing at top-level array destructuring

### DIFF
--- a/src/Doc/VariableDoc.js
+++ b/src/Doc/VariableDoc.js
@@ -27,6 +27,10 @@ export default class VariableDoc extends AbstractDoc {
         // TODO: optimize
         this._value.name = this._node.declarations[0].id.properties[0].key.name;
         break;
+      case 'ArrayPattern':
+        // TODO: optimize
+        this._value.name = this._node.declarations[0].id.elements[0].name;
+        break;
     }
   }
 

--- a/test/fixture/src/MyClass.js
+++ b/test/fixture/src/MyClass.js
@@ -319,3 +319,9 @@ export class MyClass999 {
  * @see https://github.com/esdoc/esdoc/issues/65
  */
 let {xxx, yyy, zzz} = obj;
+
+/**
+ * array destructuring used to fail.
+ * @see https://github.com/esdoc/esdoc/issues/76
+ */
+let [xxx, yyy, zzz] = [1, 2, 3];

--- a/test/fixture/src/MyClass.js
+++ b/test/fixture/src/MyClass.js
@@ -315,6 +315,7 @@ export class MyClass999 {
 }
 
 /**
+ * object destructuring used to fail.
  * @see https://github.com/esdoc/esdoc/issues/65
  */
 let {xxx, yyy, zzz} = obj;

--- a/test/src/BuilderTest/CoverageDocTest.js
+++ b/test/src/BuilderTest/CoverageDocTest.js
@@ -8,9 +8,9 @@ describe('Coverage:', ()=> {
   it('has coverage.json', ()=>{
     let json = fs.readFileSync('./test/fixture/esdoc/coverage.json', {encoding: 'utf8'}).toString();
     let coverage = JSON.parse(json);
-    assert.equal(coverage.coverage, '87.9%');
-    assert.equal(coverage.expectCount, 124);
-    assert.equal(coverage.actualCount, 109);
+    assert.equal(coverage.coverage, '88%');
+    assert.equal(coverage.expectCount, 125);
+    assert.equal(coverage.actualCount, 110);
     assert.deepEqual(coverage.files, {
       "src/ForTestDoc/AbstractDoc.js": {
         "expectCount": 3,
@@ -37,8 +37,8 @@ describe('Coverage:', ()=> {
         ]
       },
       "src/MyClass.js": {
-        "expectCount": 39,
-        "actualCount": 34,
+        "expectCount": 40,
+        "actualCount": 35,
         "undocumentLines": [
           222,
           227,


### PR DESCRIPTION
First of all, thanks for this great tool.

This PR fixes the bug #76. I referred to the previous commit 5142a9fbdc3c81939835eac0f48c84027507c2fa when writing this. I've not yet fully understood the source code of esdoc, so please let me know if there is any further line I should modify.

Cheers :smile: 