### PR TITLE
add 'verbose' option to 'config'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 /test/fixture/esdoc-cli
 /test/fixture/esdoc-plugin
 /test/fixture/esdoc-non-source
+.idea

--- a/doc/src/documents/config.html.md
+++ b/doc/src/documents/config.html.md
@@ -30,6 +30,7 @@ full config
   "index": "./README.md",
   "package": "./package.json",
   "coverage": true,
+  "verbose": true,
   "includeSource": true,
   "test": {
     "type": "mocha",
@@ -60,6 +61,7 @@ full config
 | ``index`` | - | ``./README.md``| Includes file into index page of document |
 | ``package`` | - | ``./package.json`` | Use package.json info. |
 | ``coverage`` | - | ``true`` | If true, output document coverage. |
+| ``verbose`` | - | ``true`` | If true, output full list of files. If false - only total info |
 | ``includeSource`` | - | ``true`` | If true, output includes source codes. |
 | ``test`` | - | ``null`` | If specified, Generate document from test code. |
 | ``test.type`` | true | - | Test code type. Now only support "mocha". |

--- a/src/ESDoc.js
+++ b/src/ESDoc.js
@@ -155,6 +155,8 @@ export default class ESDoc {
 
     if (!('coverage' in config)) config.coverage = true;
 
+    if (!('verbose' in config)) config.verbose = true;
+
     if (!('includeSource' in config)) config.includeSource = true;
 
     if (!config.index) config.index = './README.md';

--- a/src/Publisher/publish.js
+++ b/src/Publisher/publish.js
@@ -38,13 +38,24 @@ export default function publish(values, asts, config) {
 
   let data = taffy(values);
   let _coverage = null;
+  let _counter = {
+    html : 0,
+    badge: 0,
+    copy : 0
+  };
 
-  function log(text) {
-    console.log(text);
+  function log(text, counterKey) {
+    if (counterKey) {
+      _counter[counterKey]++;
+    }
+
+    if (config.verbose || !counterKey) {
+      console.log(text);
+    }
   }
 
   function writeHTML(html, fileName) {
-    log(fileName);
+    log(fileName, 'html');
     html = Plugin.onHandleHTML(html);
     let filePath = path.resolve(config.destination, fileName);
     fs.outputFileSync(filePath, html, {encoding: 'utf8'});
@@ -58,7 +69,7 @@ export default function publish(values, asts, config) {
   }
 
   function writeBadge(badge, fileName) {
-    log(fileName);
+    log(fileName, 'badge');
     let filePath = path.resolve(config.destination, fileName);
     fs.outputFileSync(filePath, badge, {encoding: 'utf8'});
   }
@@ -69,7 +80,7 @@ export default function publish(values, asts, config) {
   }
 
   function copy(srcPath, destPath) {
-    log(destPath);
+    log(destPath, 'copy');
     fs.copySync(srcPath, path.resolve(config.destination, destPath));
   }
 
@@ -105,5 +116,13 @@ export default function publish(values, asts, config) {
     console.log('==================================');
     console.log(`Coverage: ${_coverage.coverage} (${_coverage.actualCount}/${_coverage.expectCount})`);
     console.log('==================================');
+  }
+
+  if (!config.verbose) {
+    const reportHtml  = `${_counter.html} HTML file${_counter.html && _counter.html > 1 ? 's' : ''}`;
+    const reportBadge = `${_counter.badge} badge${_counter.badge && _counter.badge > 1 ? 's' : ''}`;
+    const reportCopy  = `${_counter.copy} file${_counter.copy && _counter.copy > 1 ? 's were' : ' was'}`;
+
+    console.log(`Total ${reportHtml} and ${reportBadge} were created, ${reportCopy} copied`);
   }
 };

--- a/src/Typedef/typedef.js
+++ b/src/Typedef/typedef.js
@@ -11,6 +11,7 @@
  * @property {boolean} [builtinExternal=true]
  * @property {boolean} [unexportIdentifier=false]
  * @property {boolean} [undocumentIdentifier=true]
+ * @property {boolean} [verbose=true]
  * @property {boolean} [coverage=true]
  * @property {boolean} [debug=false]
  * @property {string} [index="./README.md"]


### PR DESCRIPTION
I suggest to add **verbose** option to *config* (with **true** by default), which allows to output paths to all files to the console (as it is currently)

If it is set to **false**, *publisher* outputs only total info like following:

```
Total 42 HTML files and 1 badge were created, 3 files were copied
```