### PR TITLE
Parsing default params when the default is set to "{}"

### DIFF
--- a/src/Parser/ParamParser.js
+++ b/src/Parser/ParamParser.js
@@ -40,7 +40,7 @@ export default class ParamParser {
       match = value.match(/^\{(.*)\}(\s+|$)/);
       if (match) {
         typeText = match[1];
-        value = value.replace(/^\{.*\}\s*/, '');
+        value = value.replace(/^\{(.*)\}(\s+|$)/, '');
       } else {
         typeText = '*';
       }

--- a/test/fixture/src/myFunction.js
+++ b/test/fixture/src/myFunction.js
@@ -56,6 +56,14 @@ export function myFunction8(p1) {
 }
 
 /**
+ * this is myFunction9 desc.
+ * @param  {Object} [p1={}] p1
+ * @return {Object}    this is return desc
+ */
+export function myFunction9(p1 = {}) {
+}
+
+/**
  * this is myFunctionSeparateExport1.
  * @param {number} p1 - this is p1.
  */

--- a/test/src/BuilderTest/CoverageDocTest.js
+++ b/test/src/BuilderTest/CoverageDocTest.js
@@ -8,9 +8,9 @@ describe('Coverage:', ()=> {
   it('has coverage.json', ()=>{
     let json = fs.readFileSync('./test/fixture/esdoc/coverage.json', {encoding: 'utf8'}).toString();
     let coverage = JSON.parse(json);
-    assert.equal(coverage.coverage, '89.2%');
-    assert.equal(coverage.expectCount, 139);
-    assert.equal(coverage.actualCount, 124);
+    assert.equal(coverage.coverage, '89.28%');
+    assert.equal(coverage.expectCount, 140);
+    assert.equal(coverage.actualCount, 125);
     assert.deepEqual(coverage.files, {
       "src/ForTestDoc/AbstractDoc.js": {
         "expectCount": 3,
@@ -103,8 +103,8 @@ describe('Coverage:', ()=> {
         "undocumentLines": []
       },
       "src/myFunction.js": {
-        "expectCount": 10,
-        "actualCount": 8,
+        "expectCount": 11,
+        "actualCount": 9,
         "undocumentLines": [
           50,
           55

--- a/test/src/BuilderTest/FunctionDocTest.js
+++ b/test/src/BuilderTest/FunctionDocTest.js
@@ -15,8 +15,9 @@ describe('MyFunction:', ()=>{
       assert.includes(doc, '[data-ice="target"]:nth-of-type(6)', 'public * myFunction6(): Generator this is myFunction6 desc.');
       assert.includes(doc, '[data-ice="target"]:nth-of-type(7)', 'public myFunction7(p1: *[], p2: number[], p3: {}, p4: {"a": number, "b": string}): *');
       assert.includes(doc, '[data-ice="target"]:nth-of-type(8)', 'public myFunction8(p1: *)');
-      assert.includes(doc, '[data-ice="target"]:nth-of-type(9)', 'public myFunctionSeparateExport1(p1: number) this is myFunctionSeparateExport1.');
-      assert.includes(doc, '[data-ice="target"]:nth-of-type(10)', 'public myFunctionSeparateExport2(p1: number) this is myFunctionSeparateExport2.');
+      assert.includes(doc, '[data-ice="target"]:nth-of-type(9)', 'public myFunction9(p1: Object): Object this is myFunction9 desc.');
+      assert.includes(doc, '[data-ice="target"]:nth-of-type(10)', 'public myFunctionSeparateExport1(p1: number) this is myFunctionSeparateExport1.');
+      assert.includes(doc, '[data-ice="target"]:nth-of-type(11)', 'public myFunctionSeparateExport2(p1: number) this is myFunctionSeparateExport2.');
 
       assert.includes(doc, '[data-ice="target"]:nth-of-type(1) [data-ice="name"] a', 'function/index.html#static-function-myFunction1', 'href');
     });
@@ -67,11 +68,15 @@ describe('MyFunction:', ()=>{
     });
 
     find(doc, '[data-ice="detail"]:nth-of-type(9)', (doc)=>{
+      assert.includes(doc, '#static-function-myFunction9', 'public myFunction9(p1: Object): Object');
+    });
+
+    find(doc, '[data-ice="detail"]:nth-of-type(10)', (doc)=>{
       assert.includes(doc, '#static-function-myFunctionSeparateExport1', 'public myFunctionSeparateExport1(p1: number)');
       assert.includes(doc, '[data-ice="importPath"]', "import myFunctionSeparateExport1 from 'esdoc-test-fixture/src/myFunction.js'");
     });
 
-    find(doc, '[data-ice="detail"]:nth-of-type(10)', (doc)=>{
+    find(doc, '[data-ice="detail"]:nth-of-type(11)', (doc)=>{
       assert.includes(doc, '#static-function-myFunctionSeparateExport2', 'public myFunctionSeparateExport2(p1: number)');
       assert.includes(doc, '[data-ice="importPath"]', "import {myFunctionSeparateExport2} from 'esdoc-test-fixture/src/myFunction.js'");
     });

--- a/test/src/BuilderTest/NavDocTest.js
+++ b/test/src/BuilderTest/NavDocTest.js
@@ -20,17 +20,17 @@ describe('Nav:', ()=> {
       assert.includes(doc, '[data-ice="doc"]:nth-of-type(30) a', 'function/index.html#static-function-myFunction1', 'href');
 
       // variable
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(41)', 'myExport1');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(49)', 'myVariable1');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(49) a', 'variable/index.html#static-variable-myVariable1', 'href');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(41)', 'nMyAnonymous1');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(50)', 'myVariable1');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(50) a', 'variable/index.html#static-variable-myVariable1', 'href');
 
       // typedef
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(57)', 'MyTypedef1');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(57) a', 'typedef/index.html#static-typedef-MyTypedef1', 'href');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(58)', 'MyTypedef1');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(58) a', 'typedef/index.html#static-typedef-MyTypedef1', 'href');
 
       // external
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(59)', 'MyError2');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(59) a', 'example.com', 'href');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(60)', 'MyError2');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(60) a', 'example.com', 'href');
     });
   });
 });

--- a/test/src/BuilderTest/nAnonymousTest.js
+++ b/test/src/BuilderTest/nAnonymousTest.js
@@ -19,7 +19,7 @@ describe('Anonymous', ()=>{
     let doc = readDoc('function/index.html');
 
     it('has anonymous function', ()=>{
-      assert.includes(doc, '[data-ice="summary"] [data-ice="target"]:nth-of-type(11)', 'nMyAnonymous1');
+      assert.includes(doc, '[data-ice="summary"] [data-ice="target"]:nth-of-type(12)', 'nMyAnonymous1');
     });
   });
 });

--- a/test/src/UnitTest/ParamParserTest.js
+++ b/test/src/UnitTest/ParamParserTest.js
@@ -78,7 +78,7 @@ describe('ParamParser:', ()=>{
   });
 
   /** @test {ParamParser.parseParam} */
-  it('parse param with complex.', ()=>{
+  it('parse param with object ({}) as default.', ()=>{
     let value = '{!(number|string|boolean[])} [p1={}] this is desc';
     let {typeText, paramName, paramDesc} = ParamParser.parseParamValue(value);
     let result = ParamParser.parseParam(typeText, paramName, paramDesc);

--- a/test/src/UnitTest/ParamParserTest.js
+++ b/test/src/UnitTest/ParamParserTest.js
@@ -79,7 +79,7 @@ describe('ParamParser:', ()=>{
 
   /** @test {ParamParser.parseParam} */
   it('parse param with complex.', ()=>{
-    let value = '{!(number|string|boolean[])} [p1=10] this is desc';
+    let value = '{!(number|string|boolean[])} [p1={}] this is desc';
     let {typeText, paramName, paramDesc} = ParamParser.parseParamValue(value);
     let result = ParamParser.parseParam(typeText, paramName, paramDesc);
     assert.deepEqual(result, {
@@ -89,8 +89,8 @@ describe('ParamParser:', ()=>{
       optional: true,
       name: 'p1',
       description: 'this is desc',
-      defaultValue: '10',
-      defaultRaw: 10
+      defaultValue: '{}',
+      defaultRaw: {}
     });
   });
 


### PR DESCRIPTION
When setting a default parameter to an object (e.g. `funcName(argOne = {})`), the `@param` component is parsed incorrectly.

I tracked down the issue to [ParamParser.js](https://github.com/blindman/esdoc/commit/f929cdac3f04524247abe920e46e85f8b82d38a4#diff-e444415be441b7d1fff0b4819049cd75) where the regex used in the `match` function assigning to `match` and the `replace` function assigning to `value` are not the same.  I am not sure if these are purposely different but I changed them to match and added tests to account for the changes made.

Example:

![code](http://i.imgur.com/Ez3edDw.png)

![output](http://i.imgur.com/37e1NpE.png)