### PR TITLE
Proposed patch for #138

### DIFF
--- a/src/BuiltinExternal/ECMAScriptExternal.js
+++ b/src/BuiltinExternal/ECMAScriptExternal.js
@@ -190,3 +190,16 @@
 /**
  * @external {Proxy} https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
  */
+
+// Class, Method, Property
+/**
+ * @external {class} http://www.2ality.com/2015/02/es6-classes-final.html
+ */
+
+/**
+ * @external {method} http://www.2ality.com/2015/02/es6-classes-final.html
+ */
+
+/**
+ * @external {property} http://www.2ality.com/2015/02/es6-classes-final.html
+ */

--- a/src/Doc/FunctionDoc.js
+++ b/src/Doc/FunctionDoc.js
@@ -11,6 +11,7 @@ export default class FunctionDoc extends AbstractDoc {
     super['@_kind']();
     if (this._value.kind) return;
     this._value.kind = 'function';
+    this._value.decorator = false;
   }
 
   /** take out self name from self node */
@@ -57,5 +58,20 @@ export default class FunctionDoc extends AbstractDoc {
     if (result) {
       this._value.return = result;
     }
+  }
+
+  ['@decorator']() {
+    let value = this._findTagValue(['@decorator']);
+    if (!value) return;
+
+    let {typeText} = ParamParser.parseParamValue(value, true, false, false);
+    let result = ParamParser.parseParam(typeText);
+    this._value.decorator = true;
+    this._value.decorates = result;
+  }
+
+  _apply() {
+    super._apply();
+    this['@decorator']();
   }
 }

--- a/src/Publisher/Builder/IdentifiersDocBuilder.js
+++ b/src/Publisher/Builder/IdentifiersDocBuilder.js
@@ -36,6 +36,7 @@ export default class IdentifiersDocBuilder extends DocBuilder {
 
     ice.load('classSummary', this._buildSummaryHTML(null, 'class', 'Class Summary'), 'append');
     ice.load('interfaceSummary', this._buildSummaryHTML(null, 'interface', 'Interface Summary'), 'append');
+    ice.load('decoratorSummary', this._buildSummaryHTML(null, 'decorator', 'Decorator Summary'), 'append');
     ice.load('functionSummary', this._buildSummaryHTML(null, 'function', 'Function Summary'), 'append');
     ice.load('variableSummary', this._buildSummaryHTML(null, 'variable', 'Variable Summary'), 'append');
     ice.load('typedefSummary', this._buildSummaryHTML(null, 'typedef', 'Typedef Summary'), 'append');

--- a/src/Publisher/Builder/SingleDocBuilder.js
+++ b/src/Publisher/Builder/SingleDocBuilder.js
@@ -14,16 +14,21 @@ export default class SingleDocBuilder extends DocBuilder {
     let ice = this._buildLayoutDoc();
     ice.autoClose = false;
 
-    let kinds = ['function', 'variable', 'typedef'];
+    let kinds = [
+        {kind: 'function', decorator: true},
+        {kind: 'function', decorator: false},
+        {kind: 'variable'},
+        {kind: 'typedef'}
+    ];
     for (let kind of kinds) {
-      let docs = this._find({kind: kind});
+      let docs = this._find(kind);
       if (!docs.length) continue;
       let fileName = this._getOutputFileName(docs[0]);
       let baseUrl = this._getBaseUrl(fileName);
-      let title = kind.replace(/^(\w)/, (c)=> c.toUpperCase() );
+      let title = kind.kind.replace(/^(\w)/, (c)=> c.toUpperCase() );
       title = this._getTitle(title);
 
-      ice.load('content', this._buildSingleDoc(kind), IceCap.MODE_WRITE);
+      ice.load('content', this._buildSingleDoc(kind.decorator ? 'decorator' : kind.kind), IceCap.MODE_WRITE);
       ice.attr('baseUrl', 'href', baseUrl, IceCap.MODE_WRITE);
       ice.text('title', title, IceCap.MODE_WRITE);
       callback(ice.html, fileName);

--- a/src/Publisher/Builder/template/css/style.css
+++ b/src/Publisher/Builder/template/css/style.css
@@ -175,6 +175,7 @@ li > code {
 
 .kind-class,
 .kind-interface,
+.kind-decorator,
 .kind-function,
 .kind-typedef,
 .kind-variable,
@@ -197,6 +198,11 @@ li > code {
 .kind-interface {
   color: #fbca04;
   background-color: #fef2c0;
+}
+
+.kind-decorator {
+  color: #6b60d0;
+  background-color: #86bdde;
 }
 
 .kind-function {

--- a/src/Publisher/Builder/template/details.html
+++ b/src/Publisher/Builder/template/details.html
@@ -6,6 +6,7 @@
     <span class="kind" data-ice="kind"></span>
     <span class="abstract" data-ice="abstract"></span>
     <span data-ice="generator"></span>
+    <span data-ice="decorator"></span>
     <span data-ice="name"></span><span data-ice="signature"></span>
     <span class="right-info">
       <span class="version" data-ice="version">version </span>

--- a/src/Publisher/Builder/template/identifiers.html
+++ b/src/Publisher/Builder/template/identifiers.html
@@ -1,6 +1,7 @@
 <h1>References</h1>
 <div data-ice="classSummary"><h2 id="class">Class Summary</h2></div>
 <div data-ice="interfaceSummary"><h2 id="interface">Interface Summary</h2></div>
+<div data-ice="decoratorSummary"><h2 id="decorator">Decorator Summary</h2></div>
 <div data-ice="functionSummary"><h2 id="function">Function Summary</h2></div>
 <div data-ice="variableSummary"><h2 id="variable">Variable Summary</h2></div>
 <div data-ice="typedefSummary"><h2 id="typedef">Typedef Summary</h2></div>

--- a/src/Publisher/Builder/template/summary.html
+++ b/src/Publisher/Builder/template/summary.html
@@ -12,7 +12,7 @@
     <td>
       <div>
         <p>
-          <span data-ice="generator"></span> <span data-ice="name"></span><span data-ice="signature"></span>
+          <span data-ice="generator"></span> <span data-ice="decorator"></span> <span data-ice="name"></span><span data-ice="signature"></span>
         </p>
       </div>
       <div>

--- a/test/fixture/src/myDecorator.js
+++ b/test/fixture/src/myDecorator.js
@@ -1,0 +1,85 @@
+/**
+ * class decorator desc.
+ * @decorator {class}
+ * @param {class} target - the class to be decorated
+ * @return {class} - the decorated class
+ */
+export default function classDecorator(target){
+}
+
+/**
+ * static property decorator desc.
+ * @decorator {Sproperty}
+ * @param {class} target - the class to be decorated
+ * @param {string} attr - the property name
+ * @param {Object} descriptor - the property descriptor
+ * @return {Object} - the decorated property descriptor
+ */
+export function staticPropertyDecorator(target, attr, descriptor) {
+}
+
+/**
+ * static method decorator desc.
+ * @decorator {Smethod}
+ * @param {class} target - the class to be decorated
+ * @param {string} attr - the method name
+ * @param {Object} descriptor - the method descriptor
+ * @return {Object} - the decorated method descriptor
+ */
+export function staticMethodDecorator(target, attr, descriptor){
+};
+
+/**
+ * instance property decorator desc.
+ * @decorator {Iproperty}
+ * @param {Object} target - the instance to be decorated
+ * @param {string} attr - the property name
+ * @param {Object} descriptor - the property descriptor
+ * @return {Object} - the decorated property descriptor
+ */
+export function instancePropertyDecorator(target, attr, descriptor) {
+}
+
+/**
+ * instance method decorator desc.
+ * @decorator {Imethod}
+ * @param {Object} target - the instance to be decorated
+ * @param {string} attr - the method name
+ * @param {Object} descriptor - the method descriptor
+ * @return {Object} - the decorated method descriptor
+ */
+export function instanceMethodDecorator(target, attr, descriptor){
+};
+
+/**
+ * static/instance property decorator desc.
+ * @decorator {property}
+ * @param {(class|Object)} target - the class/instance to be decorated
+ * @param {string} attr - the property name
+ * @param {Object} descriptor - the property descriptor
+ * @return {Object} - the decorated property descriptor
+ */
+export function propertyDecorator(target, attr, descriptor) {
+}
+
+/**
+ * static/instance method decorator desc.
+ * @decorator {method}
+ * @param {(class|Object)} target - the class/instance to be decorated
+ * @param {string} attr - the method name
+ * @param {Object} descriptor - the method descriptor
+ * @return {Object} - the decorated method descriptor
+ */
+export function methodDecorator(target, attr, descriptor){
+};
+
+/**
+ * class/method/property decorator desc.
+ * @decorator {(class|method|property)}
+ * @param {(class|Object)} target - the class/instance to be decorated
+ * @param {string} [attr] - the method/property name
+ * @param {Object} [descriptor] - the method/property descriptor
+ * @return {Object} - the decorated class or method/property descriptor
+ */
+export function classMethodPropertyDecorator(target, attr, descriptor){
+};

--- a/test/src/BuilderTest/CoverageDocTest.js
+++ b/test/src/BuilderTest/CoverageDocTest.js
@@ -8,9 +8,9 @@ describe('Coverage:', ()=> {
   it('has coverage.json', ()=>{
     let json = fs.readFileSync('./test/fixture/esdoc/coverage.json', {encoding: 'utf8'}).toString();
     let coverage = JSON.parse(json);
-    assert.equal(coverage.coverage, '89.72%');
-    assert.equal(coverage.expectCount, 146);
-    assert.equal(coverage.actualCount, 131);
+    assert.equal(coverage.coverage, '90.25%');
+    assert.equal(coverage.expectCount, 154);
+    assert.equal(coverage.actualCount, 139);
     assert.deepEqual(coverage.files, {
       "src/ForTestDoc/AbstractDoc.js": {
         "expectCount": 3,
@@ -105,6 +105,11 @@ describe('Coverage:', ()=> {
       "src/Z003_MyInvalidLintClass.js": {
         "actualCount": 5,
         "expectCount": 5,
+        "undocumentLines": []
+      },
+      "src/myDecorator.js": {
+        "expectCount": 8,
+        "actualCount": 8,
         "undocumentLines": []
       },
       "src/myFunction.js": {

--- a/test/src/BuilderTest/IdentifiersDocTest.js
+++ b/test/src/BuilderTest/IdentifiersDocTest.js
@@ -20,6 +20,14 @@ describe('Identifiers:', ()=> {
   });
 
   /** @test {IdentifiersDocBuilder#_buildIdentifierDoc} */
+  it('has decorator summary.', ()=>{
+    find(doc, '[data-ice="decoratorSummary"]', (doc)=>{
+      assert.includes(doc, '[data-ice="target"]:nth-of-type(1)', 'public classDecorator(target: class): class class decorator desc.');
+      assert.includes(doc, '[data-ice="target"]:nth-of-type(5)', 'public methodDecorator(target: class | Object, attr: string, descriptor: Object): Object static/instance method decorator desc.');
+    });
+  });
+
+  /** @test {IdentifiersDocBuilder#_buildIdentifierDoc} */
   it('has function summary.', ()=>{
     find(doc, '[data-ice="functionSummary"]', (doc)=>{
       assert.includes(doc, '[data-ice="target"]:nth-of-type(1)', 'public myFunction1() this is myFunction1 desc.');

--- a/test/src/BuilderTest/NavDocTest.js
+++ b/test/src/BuilderTest/NavDocTest.js
@@ -15,22 +15,27 @@ describe('Nav:', ()=> {
       assert.includes(doc, '[data-ice="doc"]:nth-of-type(28)', 'MyInterface1');
       assert.includes(doc, '[data-ice="doc"]:nth-of-type(28) a', 'class/src/MyInterface.js~MyInterface1.html', 'href');
 
+      // decorator 
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(31) [data-ice="kind"]', 'D');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(31)', 'classDecorator');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(31) a', 'decorator/index.html#static-decorator-classDecorator', 'href');
+
       // function
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(31)', 'myFunction1');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(31) a', 'function/index.html#static-function-myFunction1', 'href');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(39)', 'myFunction1');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(39) a', 'function/index.html#static-function-myFunction1', 'href');
 
       // variable
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(43)', 'myExport1');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(51)', 'myVariable1');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(51) a', 'variable/index.html#static-variable-myVariable1', 'href');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(51)', 'myExport1');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(59)', 'myVariable1');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(59) a', 'variable/index.html#static-variable-myVariable1', 'href');
 
       // typedef
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(59)', 'MyTypedef1');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(59) a', 'typedef/index.html#static-typedef-MyTypedef1', 'href');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(67)', 'MyTypedef1');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(67) a', 'typedef/index.html#static-typedef-MyTypedef1', 'href');
 
       // external
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(61)', 'MyError2');
-      assert.includes(doc, '[data-ice="doc"]:nth-of-type(61) a', 'example.com', 'href');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(69)', 'MyError2');
+      assert.includes(doc, '[data-ice="doc"]:nth-of-type(69) a', 'example.com', 'href');
     });
   });
 });


### PR DESCRIPTION
todo: proper document type-of-decorator

I am still wondering how one would document the exact nature of the decorator in the generated documentation, i.e.

```
public <static method> my_decorator(...): Object

public <class> my_decorator(...): class

public <instance method> my_decorator(...): Object
```

and there is still the problem on how to document it in the first place, e.g.

```
@decorator {static method}

vs.

@decorator {Smethod}

or

@decorator {instance method}

vs.

@decorator {Imethod}
```
and so on.