### PR TITLE
adding filename to onHandleHTML() plugin event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esdoc",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Documentation Generator For JavaScript(ES6)",
   "author": "h13i32maru",
   "homepage": "https://esdoc.org/",

--- a/src/Plugin/Plugin.js
+++ b/src/Plugin/Plugin.js
@@ -113,10 +113,11 @@ class Plugin {
   /**
    * handle HTML.
    * @param {string} html - original HTML.
+   * @param {string} fileName - the fileName of the HTML file.
    * @returns {string} handled HTML.
    */
-  onHandleHTML(html) {
-    const ev = new PluginEvent({html});
+  onHandleHTML(html, fileName) {
+    const ev = new PluginEvent({html, fileName});
     this._execHandler('onHandleHTML', ev);
     return ev.data.html;
   }

--- a/src/Publisher/publish.js
+++ b/src/Publisher/publish.js
@@ -47,7 +47,7 @@ export default function publish(values, asts, config) {
 
   function writeHTML(html, fileName) {
     log(fileName);
-    html = Plugin.onHandleHTML(html);
+    html = Plugin.onHandleHTML(html, fileName);
     let filePath = path.resolve(config.destination, fileName);
     fs.outputFileSync(filePath, html, {encoding: 'utf8'});
   }

--- a/test/fixture/plugin/MyPlugin1.js
+++ b/test/fixture/plugin/MyPlugin1.js
@@ -41,6 +41,11 @@ exports.onHandleTag = function(ev) {
 exports.onHandleHTML = function(ev) {
   callInfo.handlerNames.onHandleHTML = ['MyPlugin1'];
   ev.data.html = ev.data.html.replace('MyClass_ModifiedCode_ModifiedAST_ModifiedTag', 'MyClass_ModifiedCode_ModifiedAST_ModifiedTag_ModifiedHTML');
+  // insert ev.data.fileName into <head />
+  ev.data.html = ev.data.html.replace(
+    '</head>',
+    '<meta name="x-from-plugin" content="fileName:' + ev.data.fileName + '" />\n</head>'
+  );
 };
 
 exports.onComplete = function(ev) {

--- a/test/src/UnitTest/ESDocPluginTest.js
+++ b/test/src/UnitTest/ESDocPluginTest.js
@@ -37,6 +37,7 @@ describe('Plugin:', ()=>{
 
     assert.includes(doc, 'head title', 'Modified Config');
     assert.includes(doc, '.navigation', 'MyClass_ModifiedCode_ModifiedAST_ModifiedTag_ModifiedHTML');
+    assert.includes(doc, 'head meta[name="x-from-plugin"]', 'fileName:', 'content');
   });
 
   it('call multi plugins', ()=>{


### PR DESCRIPTION
I am working on a plugin, and would like to modify the html based on the file that is being generated.

I've added a simple test case, and confirmed that the fileName is being passed in the ev.data.

This commit allows me to write plugins that do things like removing the navigation on certain pages, or adding 'active' links in the header based on a regex.

It would be nice to pass this value in *all* plugin events, but I really want it onHandleHTML().

Docs haven't been updated.

Version has been tagged and bumped to 0.4.4.