### PR TITLE
fix: Empty types give useful errors

### DIFF
--- a/src/Parser/ParamParser.js
+++ b/src/Parser/ParamParser.js
@@ -114,6 +114,13 @@ export default class ParamParser {
         result.spread = false;
       }
     }
+    else {
+      result.types = [''];
+    }
+    
+    if (result.types.some(t => !t)) {
+      throw new Error(`Empty Type found name=${paramName} desc=${paramDesc}`);
+    }
 
     if (paramName) {
       // check optional

--- a/test/fixture/empty-type.json
+++ b/test/fixture/empty-type.json
@@ -1,0 +1,7 @@
+{
+  "source": "./test/fixture/src-error",
+  "destination": "./test/fixture/empty-type",
+  "includes": ["EmptyType.js"],
+  "index": "./test/fixture/README.md",
+  "package": "./test/fixture/package.json"
+}

--- a/test/fixture/src-error/EmptyType.js
+++ b/test/fixture/src-error/EmptyType.js
@@ -1,0 +1,6 @@
+/**
+ * @throws {} Empty Type Error 1
+ */
+export default function EmptyTypeError1() {
+  
+}

--- a/test/src/UnitTest/EmptyTypeTest.js
+++ b/test/src/UnitTest/EmptyTypeTest.js
@@ -1,0 +1,22 @@
+import path from 'path';
+import ESDocCLI from '../../../src/ESDocCLI.js';
+import {readDoc, assert, find, consoleLogSwitch} from '../util.js';
+
+/** @test {EmptyType} */
+describe('EmptyType:', ()=>{
+  it('error for empty types is useful', ()=>{
+    const cliPath = path.resolve('./src/cli.js');
+    const configPath = path.resolve('./test/fixture/empty-type.json');
+    const argv = ['node', cliPath, '-c', configPath];
+    const cli = new ESDocCLI(argv);
+
+    consoleLogSwitch(false);
+    try {
+      cli.exec();
+    }
+    catch (e) {
+      assert.equal(e.message, 'Empty Type found name=null desc=Empty Type Error 1', 'Empty types should have meaningful error messages.');
+    }
+    consoleLogSwitch(true);
+  });
+});


### PR DESCRIPTION
fixes: #198

If you don't include a type it won't cause an error but if empty types are included like:

```javascript
/**
* @return {string|} has an empty component
* @throws {} this is empty
*/
function f() {
}
```

Throw an error with the name/description of the param with an empty type.