### PR TITLE
fix #202 empty repository url

### DIFF
--- a/src/Publisher/Builder/DocBuilder.js
+++ b/src/Publisher/Builder/DocBuilder.js
@@ -165,17 +165,18 @@ export default class DocBuilder {
         url = packageObj.repository;
       }
 
-      // url: git@github.com:foo/bar.git
-      if (url.indexOf('git@github.com:') === 0) {
-        let matched = url.match(/^git@github\.com:(.*)\.git$/);
-        if (matched && matched[1]) {
-          url = `https://github.com/${matched[1]}`;
+      if (typeof url === 'string') {
+        // url: git@github.com:foo/bar.git
+        if (url.indexOf('git@github.com:') === 0) {
+          let matched = url.match(/^git@github\.com:(.*)\.git$/);
+          if (matched && matched[1]) {
+            url = `https://github.com/${matched[1]}`;
+          }
         }
-      }
-
-      // url: foo/bar
-      if (url.match(/^[\w\d\-_]+\/[\w\d\-_]+$/)) {
-        url = `https://github.com/${url}`;
+        // url: foo/bar
+        if (url.match(/^[\w\d\-_]+\/[\w\d\-_]+$/)) {
+          url = `https://github.com/${url}`;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #202.

Just adds a check on `url` before attempting to parse it in case user left `repository.url` empty in `package.json`.