### PR TITLE
Fix coverage percent when expectCount is zero

### DIFF
--- a/src/Publisher/Builder/CoverageBuilder.js
+++ b/src/Publisher/Builder/CoverageBuilder.js
@@ -29,8 +29,10 @@ export default class CoverageBuilder extends DocBuilder {
       }
     }
 
+    let coveragePercent = (expectCount === 0 ? 0 : Math.floor(10000 * actualCount / expectCount) / 100);
+
     let coverage = {
-      coverage: `${Math.floor(10000 * actualCount / expectCount) / 100 }%`,
+      coverage: `${coveragePercent}%`,
       expectCount: expectCount,
       actualCount: actualCount,
       files: files


### PR DESCRIPTION
Hello :)

Fix coverage percent when file is zero.

Previous
```
==================================
Coverage: NaN% (0/0)
==================================
```

Revised
```
==================================
Coverage: 0% (0/0)
==================================
```