### PR TITLE
Support default configuration file

### DIFF
--- a/src/Util/NPMUtil.js
+++ b/src/Util/NPMUtil.js
@@ -24,4 +24,21 @@ export default class NPMUtil {
 
     return packageObj;
   }
+
+  /**
+   * Find the closest package.json file, working up from process.cwd to root.
+   * @returns {string} package.json path.
+   */
+  static findPackagePath(startDir) {
+    let dir = path.resolve(startDir || process.cwd());
+    do {
+      const packagePath = path.join(dir, 'package.json');
+      if (!fs.existsSync(packagePath)) {
+        dir = path.join(dir, '..');
+        continue;
+      }
+      return packagePath;
+    } while (dir !== path.resolve(dir, '..'));
+    return null;
+  }
 }

--- a/test/fixture/rcfiles/ConfigJSON/esdoc.json
+++ b/test/fixture/rcfiles/ConfigJSON/esdoc.json
@@ -1,0 +1,7 @@
+{
+  "source": "./test/fixture/src",
+  "destination": "./test/fixture/esdoc-cli",
+  "includes": ["MyClass\\.js"],
+  "index": "./test/fixture/README.md",
+  "package": "./test/fixture/package.json"
+}

--- a/test/fixture/rcfiles/RcJS/.esdocrc.js
+++ b/test/fixture/rcfiles/RcJS/.esdocrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  source: './test/fixture/src',
+  destination: './test/fixture/esdoc-cli',
+  includes: ['MyClass\\.js'],
+  index: './test/fixture/README.md',
+  package: './test/fixture/package.json'
+};

--- a/test/fixture/rcfiles/RcJSON/.esdocrc.json
+++ b/test/fixture/rcfiles/RcJSON/.esdocrc.json
@@ -1,0 +1,7 @@
+{
+  "source": "./test/fixture/src",
+  "destination": "./test/fixture/esdoc-cli",
+  "includes": ["MyClass\\.js"],
+  "index": "./test/fixture/README.md",
+  "package": "./test/fixture/package.json"
+}

--- a/test/fixture/rcfiles/RcLegacy/.esdocrc
+++ b/test/fixture/rcfiles/RcLegacy/.esdocrc
@@ -1,0 +1,7 @@
+{
+  "source": "./test/fixture/src",
+  "destination": "./test/fixture/esdoc-cli",
+  "includes": ["MyClass\\.js"],
+  "index": "./test/fixture/README.md",
+  "package": "./test/fixture/package.json"
+}

--- a/test/src/UnitTest/ESDocCLITest.js
+++ b/test/src/UnitTest/ESDocCLITest.js
@@ -21,4 +21,74 @@ describe('ESDocCLI:', ()=>{
     consoleLogSwitch(true);
     assert(true);
   });
+
+  /**
+   * @test {ESDocCLI#_getLocalConfigFilePath}
+   */
+  it('can find project root `esdoc.json` file.', ()=>{
+    let cliPath = path.resolve('./src/cli.js');
+    let argv = ['node', cliPath];
+    let cli = new ESDocCLI(argv);
+    assert(cli._getLocalConfigFilePath() === path.resolve('esdoc.json'));
+  });
+
+  /**
+   * @test {ESDocCLI#exec}
+   * @test {ESDocCLI#_getLocalConfigFilePath}
+   */
+  it('can execute with esdoc.json file.', ()=>{
+    let cliPath = path.resolve('./src/cli.js');
+    let rcFileDir = path.resolve('test', 'fixture', 'rcfiles', 'ConfigJSON');
+    let argv = ['node', cliPath, '--rcdir', rcFileDir];
+    let cli = new ESDocCLI(argv);
+    consoleLogSwitch(false);
+    cli.exec();
+    consoleLogSwitch(true);
+    assert(true);
+  });
+
+  /**
+   * @test {ESDocCLI#exec}
+   * @test {ESDocCLI#_getLocalConfigFilePath}
+   */
+  it('can execute with .esdocrc.js file.', ()=>{
+    let cliPath = path.resolve('./src/cli.js');
+    let rcFileDir = path.resolve('test', 'fixture', 'rcfiles', 'RcJS');
+    let argv = ['node', cliPath, '--rcdir', rcFileDir];
+    let cli = new ESDocCLI(argv);
+    consoleLogSwitch(false);
+    cli.exec();
+    consoleLogSwitch(true);
+    assert(true);
+  });
+
+  /**
+   * @test {ESDocCLI#exec}
+   * @test {ESDocCLI#_getLocalConfigFilePath}
+   */
+  it('can execute with .esdocrc.json file.', ()=>{
+    let cliPath = path.resolve('./src/cli.js');
+    let rcFileDir = path.resolve('test', 'fixture', 'rcfiles', 'RcJSON');
+    let argv = ['node', cliPath, '--rcdir', rcFileDir];
+    let cli = new ESDocCLI(argv);
+    consoleLogSwitch(false);
+    cli.exec();
+    consoleLogSwitch(true);
+    assert(true);
+  });
+
+  /**
+   * @test {ESDocCLI#exec}
+   * @test {ESDocCLI#_getLocalConfigFilePath}
+   */
+  it('can execute with .esdocrc file.', ()=>{
+    let cliPath = path.resolve('./src/cli.js');
+    let rcFileDir = path.resolve('test', 'fixture', 'rcfiles', 'RcLegacy');
+    let argv = ['node', cliPath, '--rcdir', rcFileDir];
+    let cli = new ESDocCLI(argv);
+    consoleLogSwitch(false);
+    cli.exec();
+    consoleLogSwitch(true);
+    assert(true);
+  });
 });


### PR DESCRIPTION
This pull request adds a default configuration file to `esdoc` command like eslint.

- It gives priority to config file that determined by `-c` option.
- It try to find `package.json` working up from `process.cwd()` to root.
  - and search `esdoc.json` or `.esdocrc{.js,.json,}` from siblings.
  - When not found, the same error as before will throw.
- It adds `--rcdir` option to specify project root (mainly for test).
- give options `-c` and `--rcdir` at once, `--rcdir` will be ignored.

(My motivation is to create a plug-in for editor)