### PR TITLE
Support custom manuals in esdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 out
 npm-debug.log
+.DS_Store
 /coverage
 /_temp
 /test/fixture/esdoc

--- a/esdoc.json
+++ b/esdoc.json
@@ -22,18 +22,15 @@
     }
   ],
   "manual": {
-    "customManual": true,
-    "manuals": {
-      "asset": "./manual/asset",
-      "overview": ["./manual/overview.md", "./manual/feature.md"],
-      "installation": ["./manual/installation.md"],
-      "usage": ["./manual/usage.md", "./manual/api.md"],
-      "tutorial": ["./manual/tutorial.md"],
-      "configuration": ["./manual/configuration.md"],
-      "example": ["./manual/example.md"],
-      "faq": ["./manual/faq.md"],
-      "changelog": ["./CHANGELOG.md"],
-      "customManual": ["./manual/customManual.md"]
-    }
+    "asset": "./manual/asset",
+    "overview": ["./manual/overview.md", "./manual/feature.md"],
+    "installation": ["./manual/installation.md"],
+    "usage": ["./manual/usage.md", "./manual/api.md"],
+    "tutorial": ["./manual/tutorial.md"],
+    "configuration": ["./manual/configuration.md"],
+    "example": ["./manual/example.md"],
+    "faq": ["./manual/faq.md"],
+    "changelog": ["./CHANGELOG.md"],
+    "customManual": ["./manual/customManual.md"]
   }
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -22,14 +22,18 @@
     }
   ],
   "manual": {
-    "asset": "./manual/asset",
-    "overview": ["./manual/overview.md", "./manual/feature.md"],
-    "installation": ["./manual/installation.md"],
-    "usage": ["./manual/usage.md", "./manual/api.md"],
-    "tutorial": ["./manual/tutorial.md"],
-    "configuration": ["./manual/configuration.md"],
-    "example": ["./manual/example.md"],
-    "faq": ["./manual/faq.md"],
-    "changelog": ["./CHANGELOG.md"]
+    "customManual": true,
+    "manuals": {
+      "asset": "./manual/asset",
+      "overview": ["./manual/overview.md", "./manual/feature.md"],
+      "installation": ["./manual/installation.md"],
+      "usage": ["./manual/usage.md", "./manual/api.md"],
+      "tutorial": ["./manual/tutorial.md"],
+      "configuration": ["./manual/configuration.md"],
+      "example": ["./manual/example.md"],
+      "faq": ["./manual/faq.md"],
+      "changelog": ["./CHANGELOG.md"],
+      "customManual": ["./manual/customManual.md"]
+    }
   }
 }

--- a/manual/customManual.md
+++ b/manual/customManual.md
@@ -1,0 +1,5 @@
+# CustomManual File
+
+## Whith no content
+
+* at the moment

--- a/manual/customManual.md
+++ b/manual/customManual.md
@@ -1,5 +1,5 @@
 # CustomManual File
 
-## Whith no content
+## With no content
 
 * at the moment

--- a/src/Publisher/Builder/ManualDocBuilder.js
+++ b/src/Publisher/Builder/ManualDocBuilder.js
@@ -54,17 +54,29 @@ export default class ManualDocBuilder extends DocBuilder {
    * @private
    */
   _getManualConfig() {
-    const m = this._config.manual;
+    const m = this._config.manual["manuals"];
     const manualConfig = [];
-    if (m.overview) manualConfig.push({label: 'Overview', paths: m.overview});
-    if (m.installation) manualConfig.push({label: 'Installation', paths: m.installation});
-    if (m.tutorial) manualConfig.push({label: 'Tutorial', paths: m.tutorial});
-    if (m.usage) manualConfig.push({label: 'Usage', paths: m.usage});
-    if (m.configuration) manualConfig.push({label: 'Configuration', paths: m.configuration});
-    if (m.example) manualConfig.push({label: 'Example', paths: m.example});
-    manualConfig.push({label: 'Reference', fileName: 'identifiers.html', references: true});
-    if (m.faq) manualConfig.push({label: 'FAQ', paths: m.faq});
-    if (m.changelog) manualConfig.push({label: 'Changelog', paths: m.changelog});
+
+    if (!this._config.manual["customManual"]) {
+      if (m.overview) manualConfig.push({label: 'Overview', paths: m.overview});
+      if (m.installation) manualConfig.push({label: 'Installation', paths: m.installation});
+      if (m.tutorial) manualConfig.push({label: 'Tutorial', paths: m.tutorial});
+      if (m.usage) manualConfig.push({label: 'Usage', paths: m.usage});
+      if (m.configuration) manualConfig.push({label: 'Configuration', paths: m.configuration});
+      if (m.example) manualConfig.push({label: 'Example', paths: m.example});
+      manualConfig.push({label: 'Reference', fileName: 'identifiers.html', references: true});
+      if (m.faq) manualConfig.push({label: 'FAQ', paths: m.faq});
+      if (m.changelog) manualConfig.push({label: 'Changelog', paths: m.changelog});
+    } else {
+      for (var file in m) {
+        if (file != 'asset') {
+          let label = file.charAt(0).toUpperCase() + file.slice(1);
+          manualConfig.push({label: label, paths: m[file]});
+        }
+      }
+      manualConfig.push({label: 'Reference', fileName: 'identifiers.html', references: true});
+    }
+
     return manualConfig;
   }
 

--- a/src/Publisher/Builder/ManualDocBuilder.js
+++ b/src/Publisher/Builder/ManualDocBuilder.js
@@ -57,9 +57,9 @@ export default class ManualDocBuilder extends DocBuilder {
     const m = this._config.manual;
     const manualConfig = [];
 
-    for (var file in m) {
-      if (file != 'asset') {
-        let label = file.charAt(0).toUpperCase() + file.slice(1);
+    for (let file in m) {
+      if (file !== 'asset' && file !== 'reference') {
+        const label = file.charAt(0).toUpperCase() + file.slice(1);
         manualConfig.push({label: label, paths: m[file]});
       }
     }

--- a/src/Publisher/Builder/ManualDocBuilder.js
+++ b/src/Publisher/Builder/ManualDocBuilder.js
@@ -54,28 +54,16 @@ export default class ManualDocBuilder extends DocBuilder {
    * @private
    */
   _getManualConfig() {
-    const m = this._config.manual["manuals"];
+    const m = this._config.manual;
     const manualConfig = [];
 
-    if (!this._config.manual["customManual"]) {
-      if (m.overview) manualConfig.push({label: 'Overview', paths: m.overview});
-      if (m.installation) manualConfig.push({label: 'Installation', paths: m.installation});
-      if (m.tutorial) manualConfig.push({label: 'Tutorial', paths: m.tutorial});
-      if (m.usage) manualConfig.push({label: 'Usage', paths: m.usage});
-      if (m.configuration) manualConfig.push({label: 'Configuration', paths: m.configuration});
-      if (m.example) manualConfig.push({label: 'Example', paths: m.example});
-      manualConfig.push({label: 'Reference', fileName: 'identifiers.html', references: true});
-      if (m.faq) manualConfig.push({label: 'FAQ', paths: m.faq});
-      if (m.changelog) manualConfig.push({label: 'Changelog', paths: m.changelog});
-    } else {
-      for (var file in m) {
-        if (file != 'asset') {
-          let label = file.charAt(0).toUpperCase() + file.slice(1);
-          manualConfig.push({label: label, paths: m[file]});
-        }
+    for (var file in m) {
+      if (file != 'asset') {
+        let label = file.charAt(0).toUpperCase() + file.slice(1);
+        manualConfig.push({label: label, paths: m[file]});
       }
-      manualConfig.push({label: 'Reference', fileName: 'identifiers.html', references: true});
     }
+    manualConfig.push({label: 'Reference', fileName: 'identifiers.html', references: true});
 
     return manualConfig;
   }

--- a/test/src/BuilderTest/ManualDocTest.js
+++ b/test/src/BuilderTest/ManualDocTest.js
@@ -1,6 +1,6 @@
 import {getEsdoc, readDoc, assert, find} from './../util.js';
 
-let m = JSON.parse( getEsdoc() ).manual;
+const m = JSON.parse( getEsdoc() ).manual;
 
 /** @test {ManualDocBuilder} */
 describe('Manual:', ()=>{
@@ -15,12 +15,12 @@ describe('Manual:', ()=>{
   it('has manual navigation', ()=>{
     const doc = readDoc('manual/index.html');
 
-    var i = 1;
-    for (var file in m) {
-      if (file != 'asset') {
+    let i = 1;
+    for (let file in m) {
+      if (file !== 'asset' && file !== 'reference') {
 
-        let label = file.charAt(0).toUpperCase() + file.slice(1);
-        let f = file.split('.')[0]+'.html';
+        const label = file.charAt(0).toUpperCase() + file.slice(1);
+        const f = file.split('.')[0]+'.html';
 
         find(doc, '[data-ice="nav"]', (doc)=>{
           assert.includes(doc, '[data-ice="manual"]:nth-of-type('+i+')', ''+label);

--- a/test/src/BuilderTest/ManualDocTest.js
+++ b/test/src/BuilderTest/ManualDocTest.js
@@ -1,7 +1,10 @@
-import {readDoc, assert, find} from './../util.js';
+import {getEsdoc, readDoc, assert, find} from './../util.js';
+
+let m = JSON.parse( getEsdoc() ).manual;
 
 /** @test {ManualDocBuilder} */
 describe('Manual:', ()=>{
+
   it('has manual link in header', ()=>{
     const doc = readDoc('index.html');
     assert.includes(doc, '[data-ice="manualHeaderLink"]', 'Manual');
@@ -11,135 +14,44 @@ describe('Manual:', ()=>{
   /** @test {ManualDocBuilder#_buildManualNav} */
   it('has manual navigation', ()=>{
     const doc = readDoc('manual/index.html');
-    find(doc, '[data-ice="nav"]', (doc)=>{
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(1)', 'Overview');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(2)', 'Installation');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(3)', 'Tutorial');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(4)', 'Usage');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(5)', 'Configuration');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(6)', 'Example');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(7)', 'Reference');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(8)', 'FAQ');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(9)', 'Changelog');
 
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(1) .manual-toc-title a', 'manual/overview.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(2) .manual-toc-title a', 'manual/installation.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(3) .manual-toc-title a', 'manual/tutorial.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(4) .manual-toc-title a', 'manual/usage.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(5) .manual-toc-title a', 'manual/configuration.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(6) .manual-toc-title a', 'manual/example.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(7) .manual-toc-title a', 'identifiers.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(8) .manual-toc-title a', 'manual/faq.html', 'href');
-      assert.includes(doc, '[data-ice="manual"]:nth-of-type(9) .manual-toc-title a', 'manual/changelog.html', 'href');
-    });
+    var i = 1;
+    for (var file in m) {
+      if (file != 'asset') {
+
+        let label = file.charAt(0).toUpperCase() + file.slice(1);
+        let f = file.split('.')[0]+'.html';
+
+        find(doc, '[data-ice="nav"]', (doc)=>{
+          assert.includes(doc, '[data-ice="manual"]:nth-of-type('+i+')', ''+label);
+          assert.includes(doc, '[data-ice="manual"]:nth-of-type('+i+') .manual-toc-title a', 'manual/'+f, 'href');
+        });
+
+        i++;
+      }
+    }
+
   });
 
   /** @test {ManualDocBuilder#_buildManualIndex} */
   it('has each heading tags', ()=>{
     const doc = readDoc('manual/index.html');
 
-    // overview
-    find(doc, '.content [data-ice="manual"]:nth-of-type(1)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Overview');
+    var i = 1;
+    for (var file in m) {
+      if (file != 'asset') {
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Overview');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'Feature');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3)', 'Demo');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(4)', 'License');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(5)', 'Author');
+        let label = file.charAt(0).toUpperCase() + file.slice(1);
+        let f = file.split('.')[0]+'.html';
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/overview.html#overview', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/overview.html#feature', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3) a', 'manual/overview.html#demo', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(4) a', 'manual/overview.html#license', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(5) a', 'manual/overview.html#author', 'href');
-    });
+        find(doc, '.content [data-ice="manual"]:nth-of-type('+i+')', (doc)=>{
+          assert.includes(doc, '.manual-toc-title', label);
+        });
 
-    // installation
-    find(doc, '.content [data-ice="manual"]:nth-of-type(2)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Installation');
+        i++;
+      }
+    }
 
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Installation');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'indent 2');
-      assert.includes(doc, '.indent-h3[data-ice="manualNav"]:nth-of-type(3)', 'indent 3');
-      assert.includes(doc, '.indent-h4[data-ice="manualNav"]:nth-of-type(4)', 'indent 4');
-      assert.includes(doc, '.indent-h5[data-ice="manualNav"]:nth-of-type(5)', 'indent 5');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/installation.html#installation', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/installation.html#indent-2', 'href');
-      assert.includes(doc, '.indent-h3[data-ice="manualNav"]:nth-of-type(3) a', 'manual/installation.html#indent-3', 'href');
-      assert.includes(doc, '.indent-h4[data-ice="manualNav"]:nth-of-type(4) a', 'manual/installation.html#indent-4', 'href');
-      assert.includes(doc, '.indent-h5[data-ice="manualNav"]:nth-of-type(5) a', 'manual/installation.html#indent-5', 'href');
-    });
-
-    // tutorial
-    find(doc, '.content [data-ice="manual"]:nth-of-type(3)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Tutorial');
-    });
-
-    // usage
-    find(doc, '.content [data-ice="manual"]:nth-of-type(4)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Usage');
-    });
-
-    // configuration
-    find(doc, '.content [data-ice="manual"]:nth-of-type(5)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Configuration');
-    });
-
-    // example
-    find(doc, '.content [data-ice="manual"]:nth-of-type(6)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Example');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Example');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'Minimum Config');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3)', 'Integration Test Code Into Documentation');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/example.html#example', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/example.html#minimum-config', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(3) a', 'manual/example.html#integration-test-code-into-documentation', 'href');
-    });
-
-    // reference
-    find(doc, '.content [data-ice="manual"]:nth-of-type(7)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Reference');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Class');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(2)', 'Interface');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(3)', 'Function');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(4)', 'Variable');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(5)', 'Typedef');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(6)', 'External');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'identifiers.html#class', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(2) a', 'identifiers.html#interface', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(3) a', 'identifiers.html#function', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(4) a', 'identifiers.html#variable', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(5) a', 'identifiers.html#typedef', 'href');
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(6) a', 'identifiers.html#external', 'href');
-    });
-
-    // faq
-    find(doc, '.content [data-ice="manual"]:nth-of-type(8)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'FAQ');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'FAQ');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', 'Goal');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/faq.html#faq', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/faq.html#goal', 'href');
-    });
-
-    // changelog
-    find(doc, '.content [data-ice="manual"]:nth-of-type(9)', (doc)=>{
-      assert.includes(doc, '.manual-toc-title', 'Changelog');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1)', 'Changelog');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2)', '0.0.1');
-
-      assert.includes(doc, '.indent-h1[data-ice="manualNav"]:nth-of-type(1) a', 'manual/changelog.html#changelog', 'href');
-      assert.includes(doc, '.indent-h2[data-ice="manualNav"]:nth-of-type(2) a', 'manual/changelog.html#0-0-1', 'href');
-    });
   });
 
   /** @test {ManualDocBuilder#_buldManual} */

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -3,6 +3,10 @@ import fs from 'fs';
 import path from 'path';
 import cheerio from 'cheerio';
 
+export function getEsdoc() {
+  return fs.readFileSync(`./test/fixture/esdoc.json`, {encoding: 'utf-8'});
+}
+
 export function readDoc(fileName, dirName = 'esdoc') {
   let html = fs.readFileSync(`./test/fixture/${dirName}/${fileName}`, {encoding: 'utf-8'});
   let $ = cheerio.load(html);


### PR DESCRIPTION
I use esdoc for a recent project where I have to add concepts in my documentation. I figured out that esdoc only support hardcoded manuals. I hope this feature will help to add more flexibility to esdoc.

Cheers Lucas