### PR TITLE
handle repo urls that start with git+

### DIFF
--- a/src/Publisher/Builder/DocBuilder.js
+++ b/src/Publisher/Builder/DocBuilder.js
@@ -177,6 +177,11 @@ export default class DocBuilder {
         if (url.match(/^[\w\d\-_]+\/[\w\d\-_]+$/)) {
           url = `https://github.com/${url}`;
         }
+        // url: git+https://
+        if (/^git\+http.+$/.test(url)) {
+          // https://regex101.com/r/nW4wC2/2
+          url = url.match(/^git\+(.+)$/)[1];
+        }
       }
     }
 


### PR DESCRIPTION
Fixes: #235 

This PR updates the existing logic around package.json repository property.  It does not change it to read from the "homepage" property.  I felt switching from repository to homepage would probably break more people than just updating the logic around repository.