### PR TITLE
Member tag

### DIFF
--- a/doc/src/documents/tags.html.md
+++ b/doc/src/documents/tags.html.md
@@ -19,7 +19,7 @@ class MyClass {
    * this is constructor description.
    * @param {number} arg1 this is arg1 description.
    * @param {string[]} arg2 this is arg2 description.
-   */ 
+   */
   constructor(arg1, arg2) {...}
 }
 ```
@@ -41,6 +41,7 @@ class MyClass {
   - [@extends](#-extends)
   - [@implements](#-implements)
   - [@interface](#-interface)
+  - [@member](#-member)
 - [For Method And Function](#for-method-and-function)
   - [@abstract](#-abstract)
   - [@emits](#-emits)
@@ -131,7 +132,7 @@ syntax: ``@example <JavaScript>``
  * let myClass = new MyClass();
  * let result = myClass.foo();
  * console.log(result);
- * 
+ *
  * @example
  * let result = MyClass.bar();
  * console.log(result);
@@ -279,6 +280,22 @@ syntax: ``@interface``
  * @interface
  */
 class MyInterface {...}
+```
+
+----
+
+#### @member
+syntax: ``@member``
+
+Specify a class member.   
+ESDoc normally finds class members in your code by itself. Use this tag if you want
+to explicitly document a class member.
+
+```javascript
+/**
+ * @member {number} foo
+ */
+class MyClass {...}
 ```
 
 ----
@@ -642,4 +659,3 @@ if same names in your project, you can use full identifier syntax. full identifi
 e.g. If ``MyClass`` in ``src/foo1.js`` and ``src/foo2.js``, you can write following,
 - ``src/foo1.js~MyClass``
 - ``src/foo2.js~MyClass``
-

--- a/src/Doc/AbstractDoc.js
+++ b/src/Doc/AbstractDoc.js
@@ -24,6 +24,7 @@ export default class AbstractDoc {
     this._pathResolver = pathResolver;
     this._commentTags = commentTags;
     this._value = {};
+    this._extras = [];
 
     Object.defineProperty(this._node, 'doc', {value: this});
 
@@ -35,6 +36,10 @@ export default class AbstractDoc {
   /** @type {DocObject[]} */
   get value() {
     return JSON.parse(JSON.stringify(this._value));
+  }
+
+  get extras() {
+    return JSON.parse(JSON.stringify(this._extras));
   }
 
   /**
@@ -506,6 +511,15 @@ export default class AbstractDoc {
     if (tag) {
       this._value.generator = true;
     }
+  }
+
+
+  /**
+   * Saves an additional documentation node value to be added to the db.
+   * @param  {object} extra Extra node value
+   */
+  _addExtraValue(extra) {
+    this._extras.push(extra);
   }
 
   /**

--- a/src/Doc/ClassDoc.js
+++ b/src/Doc/ClassDoc.js
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import AbstractDoc from './AbstractDoc.js';
 import ParamParser from '../Parser/ParamParser.js';
 import NamingUtil from '../Util/NamingUtil.js';
+import ASTNodeContainer from '../Util/ASTNodeContainer.js';
 
 /**
  * Doc Class from Class Declaration AST node.
@@ -17,6 +18,32 @@ export default class ClassDoc extends AbstractDoc {
     this['@interface']();
     this['@extends']();
     this['@implements']();
+    this['@member']();
+  }
+
+  ['@member']() {
+    let values = this._findAllTagValues(['@member']);
+    if (!values) return;
+
+    this._value.members = [];
+    for (let value of values) {
+      let {typeText, paramName, paramDesc} = ParamParser.parseParamValue(value);
+      let result = ParamParser.parseParam(typeText, paramName, paramDesc);
+      let types = result.types;
+      this._addExtraValue({
+        __docId__: ASTNodeContainer.addNode(this._node),
+        kind: 'member',
+        static: false,
+        name: result.name,
+        description: result.description,
+        type: {types},
+        variation: null,
+        access: 'public',
+        lineNumber: this._value.lineNumber,
+        memberof: this._value.longname,
+        longname: this._value.longname + '#' + result.name
+      });
+    }
   }
 
   /** specify ``class`` to kind. */

--- a/src/Factory/DocFactory.js
+++ b/src/Factory/DocFactory.js
@@ -356,9 +356,10 @@ export default class DocFactory {
         doc = this._createDoc(virtualNode, tags);
       }
 
-      if (doc) results.push(doc.value);
+      if (doc) {
+        results = [...results, doc.value, ...doc.extras];
+      }
     }
-
     return results;
   }
 

--- a/src/Publisher/Builder/DocResolver.js
+++ b/src/Publisher/Builder/DocResolver.js
@@ -412,7 +412,12 @@ export default class DocResolver {
       // member duplicate with getter/setter/method.
       // when it, remove member.
       // getter/setter/method are high priority.
-      const nonMemberDup = this._builder._find({longname: doc.longname, kind: {'!is': 'member'}});
+      const nonMemberDup = this._builder._find(
+        {longname: doc.longname, kind: {'!is': 'member'}},
+        // should use isUndefined here but using a function instead
+        // because of https://github.com/typicaljoe/taffydb/issues/114
+        function() { return !this.ignore; });
+
       if (nonMemberDup.length) {
         ignoreId.push(doc.___id);
         continue;
@@ -429,10 +434,7 @@ export default class DocResolver {
       }
     }
 
-    this._data({___id: ignoreId}).update(function(){
-      this.ignore = true;
-      return this;
-    });
+    this._data({___id: ignoreId}).update({ignore: true});
 
     this._data.__RESOLVED_DUPLICATION__ = true;
   }

--- a/test/fixture/src/MyClass.js
+++ b/test/fixture/src/MyClass.js
@@ -50,6 +50,9 @@ import SuperMyClass1 from './OtherClass/SuperMyClass.js';
  * @see {@link SuperMyClass1#superMethod}
  * @since 1.2.3
  * @version 0.0.1
+ * @member {number} userDefined This member is defined using the `member` tag
+ * @member {number} userDefinedHidden This member is hidden by a getter
+ * @member {number} userDefinedVisible This member is defined on top of an `ignore`d getter.
  * @foobar this is unknown tag.
  */
 export default class MyClass1 extends SuperMyClass1 {
@@ -148,6 +151,19 @@ export default class MyClass1 extends SuperMyClass1 {
     // this is undocument
     const prop = 'p999';
     this[prop] = 123;
+  }
+
+  /**
+   * This getter hides the member of the same name defined with @member
+   */
+  get userDefinedHidden() {
+  }
+
+  /**
+   * This getter is ignored so it gives way to the member of the same name defined with @member
+   * @ignore
+   */
+  get userDefinedVisible() {
   }
 
   /**

--- a/test/src/BuilderTest/ClassDocTest.js
+++ b/test/src/BuilderTest/ClassDocTest.js
@@ -16,7 +16,7 @@ describe('MyClass1:', ()=> {
       assert.includes(doc, '[data-ice="access"]', 'public');
       assert.includes(doc, '[data-ice="kind"]', 'class');
       assert.includes(doc, '[data-ice="source"]', 'source');
-      assert.includes(doc, '[data-ice="source"] a', 'file/src/MyClass.js.html#lineNumber55', 'href');
+      assert.includes(doc, '[data-ice="source"] a', 'file/src/MyClass.js.html#lineNumber58', 'href');
       assert.includes(doc, '[data-ice="version"]', 'version 0.0.1');
       assert.includes(doc, '[data-ice="since"]', 'since 1.2.3');
     });
@@ -164,12 +164,12 @@ describe('MyClass1:', ()=> {
         assert.includes(doc, '[data-ice="target"]:nth-of-type(4)', 'public p7: *');
 
         // value
-        assert.includes(doc, '[data-ice="target"]:nth-of-type(5)', 'public get value: number this is value(get) desc.');
-        assert.includes(doc, '[data-ice="target"]:nth-of-type(5) [data-ice="name"] a', 'class/src/MyClass.js~MyClass1.html#instance-get-value', 'href');
+        assert.includes(doc, '[data-ice="target"]:nth-of-type(8)', 'public get value: number this is value(get) desc.');
+        assert.includes(doc, '[data-ice="target"]:nth-of-type(8) [data-ice="name"] a', 'class/src/MyClass.js~MyClass1.html#instance-get-value', 'href');
 
         // value
-        assert.includes(doc, '[data-ice="target"]:nth-of-type(6)', 'public set value: number this is value(set) desc.');
-        assert.includes(doc, '[data-ice="target"]:nth-of-type(6) [data-ice="name"] a', 'class/src/MyClass.js~MyClass1.html#instance-set-value', 'href');
+        assert.includes(doc, '[data-ice="target"]:nth-of-type(9)', 'public set value: number this is value(set) desc.');
+        assert.includes(doc, '[data-ice="target"]:nth-of-type(9) [data-ice="name"] a', 'class/src/MyClass.js~MyClass1.html#instance-set-value', 'href');
       });
 
       // protected
@@ -351,22 +351,22 @@ describe('MyClass1:', ()=> {
       });
 
       // public value
-      find(doc, '[data-ice="detail"]:nth-of-type(5)', (doc)=> {
+      find(doc, '[data-ice="detail"]:nth-of-type(8)', (doc)=> {
         assert.includes(doc, '#instance-get-value', 'public get value: number');
       });
 
       // public value
-      find(doc, '[data-ice="detail"]:nth-of-type(6)', (doc)=> {
+      find(doc, '[data-ice="detail"]:nth-of-type(9)', (doc)=> {
         assert.includes(doc, '#instance-set-value', 'public set value: number');
       });
 
       // protected p2
-      find(doc, '[data-ice="detail"]:nth-of-type(7)', (doc)=>{
+      find(doc, '[data-ice="detail"]:nth-of-type(10)', (doc)=>{
         assert.includes(doc, '#instance-member-p2', 'protected p2: number');
       });
 
       // private p3
-      find(doc, '[data-ice="detail"]:nth-of-type(8)', (doc)=>{
+      find(doc, '[data-ice="detail"]:nth-of-type(11)', (doc)=>{
         assert.includes(doc, '#instance-member-p3', 'private p3: number');
       });
     })
@@ -488,4 +488,3 @@ describe('MyClass1:', ()=> {
     })
   });
 });
-

--- a/test/src/BuilderTest/CoverageDocTest.js
+++ b/test/src/BuilderTest/CoverageDocTest.js
@@ -8,9 +8,9 @@ describe('Coverage:', ()=> {
   it('has coverage.json', ()=>{
     let json = fs.readFileSync('./test/fixture/esdoc/coverage.json', {encoding: 'utf8'}).toString();
     let coverage = JSON.parse(json);
-    assert.equal(coverage.coverage, '89.79%');
-    assert.equal(coverage.expectCount, 147);
-    assert.equal(coverage.actualCount, 132);
+    assert.equal(coverage.coverage, '90%');
+    assert.equal(coverage.expectCount, 150);
+    assert.equal(coverage.actualCount, 135);
     assert.deepEqual(coverage.files, {
       "src/ForTestDoc/AbstractDoc.js": {
         "expectCount": 3,
@@ -37,14 +37,14 @@ describe('Coverage:', ()=> {
         ]
       },
       "src/MyClass.js": {
-        "expectCount": 43,
-        "actualCount": 38,
+        "expectCount": 46,
+        "actualCount": 41,
         "undocumentLines": [
-          226,
-          231,
-          144,
-          145,
-          146
+          242,
+          247,
+          147,
+          148,
+          149
         ]
       },
       "src/MyError.js": {


### PR DESCRIPTION
This proposal fixes #255 by adding a '@member' tag for classes.

usage:
```js
/**
 * A class with hidden members
 * @member {number} myAttribute Some random attribute
 */
class MyClass {
...
```

I made 3 changes to make this work:
1. A Doc class (subclass of `Doc/AbstractDoc`) can now add additional entries to the database, other than this._value (this allows to generate doc entries from doc tags).
2. Add the member tag to ClassDoc
3. make sure that ignored getters and setters don't hide a class member (this way you can define a member with @member and hide get/set as well).

The PR comes with an additional doc entry and tests.

By the way, this module is awesome, good job @h13i32maru :+1: 