### PR TITLE
Exposed more variables to ESParser related plugin callbacks.

### DIFF
--- a/src/Parser/ESParser.js
+++ b/src/Parser/ESParser.js
@@ -18,7 +18,7 @@ export default class ESParser {
   static parse(filePath) {
     let code = fs.readFileSync(filePath, {encode: 'utf8'}).toString();
 
-    code = Plugin.onHandleCode(code);
+    code = Plugin.onHandleCode(code, filePath);
 
     if (code.charAt(0) === '#') {
       code = code.replace(/^#!/, '//');
@@ -58,11 +58,11 @@ export default class ESParser {
       return espree.parse(code, option);
     };
 
-    parser = Plugin.onHandleCodeParser(parser);
+    parser = Plugin.onHandleCodeParser(parser, option, filePath, code);
 
     let ast = parser(code);
 
-    ast = Plugin.onHandleAST(ast);
+    ast = Plugin.onHandleAST(ast, filePath, code);
 
     return ast;
   }

--- a/src/Plugin/Plugin.js
+++ b/src/Plugin/Plugin.js
@@ -68,10 +68,12 @@ class Plugin {
   /**
    * handle code.
    * @param {string} code - original code.
+   * @param {string} filePath - source code file path.
    * @returns {string} handled code.
    */
-  onHandleCode(code) {
+  onHandleCode(code, filePath) {
     const ev = new PluginEvent({code});
+    ev.data.filePath = filePath;
     this._execHandler('onHandleCode', ev);
     return ev.data.code;
   }
@@ -79,11 +81,14 @@ class Plugin {
   /**
    * handle code parser.
    * @param {function(code: string)} parser - original js parser.
+   * @param {object} option - default Espree options.
+   * @param {string} filePath - source code file path.
+   * @param {string} code - original code.
    * @returns {function(code: string)} handled parser.
    */
-  onHandleCodeParser(parser) {
+  onHandleCodeParser(parser, option, filePath, code) {
     const ev = new PluginEvent();
-    ev.data.parser = parser;
+    ev.data = { parser: parser, option: option, filePath: filePath, code: code };
     this._execHandler('onHandleCodeParser', ev);
     return ev.data.parser;
   }
@@ -91,10 +96,14 @@ class Plugin {
   /**
    * handle AST.
    * @param {AST} ast - original ast.
+   * @param {string} filePath - source code file path.
+   * @param {string} code - original code.
    * @returns {AST} handled AST.
    */
-  onHandleAST(ast) {
+  onHandleAST(ast, filePath, code) {
     const ev = new PluginEvent({ast});
+    ev.data.filePath = filePath;
+    ev.data.code = code;
     this._execHandler('onHandleAST', ev);
     return ev.data.ast;
   }


### PR DESCRIPTION
@h13i32maru Please review this PR as it exposes all data available in ESParser to parsing related plugin callbacks. It is rather handy to have the file path (`filePath`) for instance in `onHandleCode` and `onHandleAST` for the source code being processed. 

Please let me know if any changes need to be made and I'll update the PR. I have a really significant ESDoc plugin for interactive visualization of source code that is blocked without more plugin data for AST processing. 