### PR TITLE
Add options in help

### DIFF
--- a/src/ESDocCLI.js
+++ b/src/ESDocCLI.js
@@ -54,7 +54,13 @@ export default class ESDocCLI {
    * @private
    */
   _showHelp() {
-    console.log('usage: esdoc [-c esdoc.json]');
+    console.log('Usage: esdoc [-c esdoc.json]');
+    console.log('');
+    console.log('Options:');
+    console.log('  -c', 'create the documents');
+    console.log('  -h', 'output usage information');
+    console.log('  -v', 'output the version number');
+    console.log('');
   }
 
   /**


### PR DESCRIPTION
hello:)

I added command options in help.

```
ᐅ esdoc -h
usage: esdoc [-c esdoc.json]

Options:
  -c create the documents
  -h output usage information
  -v output the version number

```

thanks.