### PR TITLE
Add support for files arrays

### DIFF
--- a/src/ESDoc.js
+++ b/src/ESDoc.js
@@ -61,7 +61,7 @@ export default class ESDoc {
     let asts = [];
     let sourceDirPath = path.resolve(config.source);
 
-    this._walk(config.source, (filePath)=>{
+    const processFile = (filePath)=>{
       const relativeFilePath = path.relative(sourceDirPath, filePath);
       let match = false;
       for (let reg of includes) {
@@ -81,7 +81,13 @@ export default class ESDoc {
       results.push(...temp.results);
 
       asts.push({filePath: 'source' + path.sep + relativeFilePath, ast: temp.ast});
-    });
+    };
+
+    if (Array.isArray(config.files)) {
+      config.files.forEach(processFile);
+    } else {
+      this._walk(config.source, processFile);
+    }
 
     if (config.builtinExternal) {
       this._useBuiltinExternal(results);

--- a/src/Typedef/typedef.js
+++ b/src/Typedef/typedef.js
@@ -4,6 +4,7 @@
  * @property {!string} source - directory path of javascript source code.
  * @property {!string} destination - directory path of output.
  * @property {string} [title]
+ * @property {string[]} [files]
  * @property {string[]} [includes=["\\.(js|es6)$"]]
  * @property {string[]} [excludes=["\\.config\\.(js|es6)$"]]
  * @property {string[]} [access=["public", "protected"]]


### PR DESCRIPTION
This PR provides a widely wanted ability to pass arrays of files to be processed by doc generator instead of specifying includes/excludes regexps. This is very handy to use with https://www.npmjs.com/package/glob.
```
const glob = require('glob');
const path = require('path');
export default {
 source: '.',
 files: [].concat(
  glob.sync(path.resolve('./src/somedir/**/*.js)),
  glob.sync(path.resolve('./src/users/*/config/**/*.js))
 )
}
```

As you can see it's just a few lines of code.

Fixes #72, #86, #210, #270