### PR TITLE
Correct `v` documentation in typedef.js

### DIFF
--- a/src/Typedef/typedef.js
+++ b/src/Typedef/typedef.js
@@ -90,7 +90,7 @@
  * @typedef {Object} ESDocCLIArgv
  * @property {boolean} [h] - for help
  * @property {boolean} [help] - for help
- * @property {boolean [v] - for version
+ * @property {boolean} [v] - for version
  * @property {boolean} [version] - for version
  * @property {string} [c] - for config file path
  * @property {string[]} [_] - for source directory path


### PR DESCRIPTION
Previously the documentation form `[v]` was missing a close-curly (`}`) which caused the rest of the line to be parsed incorrectly.