### PR TITLE
Remove internal tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/esdoc/esdoc"
   },
+  "engines" : {
+    "node" : ">= 6.0.0"
+  },
   "scripts": {
     "build": "node ./script/build.js",
     "test": "node ./script/test.js",

--- a/src/Doc/AbstractDoc.js
+++ b/src/Doc/AbstractDoc.js
@@ -40,49 +40,49 @@ export default class AbstractDoc {
    * @protected
    */
   _apply() {
-    this['@_kind']();
-    this['@_static']();
-    this['@_variation']();
-    this['@_name']();
-    this['@_memberof']();
-    this['@_longname']();
-    this['@access']();
-    this['@_export']();
-    this['@_importPath']();
-    this['@_importStyle']();
-    this['@desc']();
-    this['@example']();
-    this['@see']();
-    this['@_lineNumber']();
-    this['@deprecated']();
-    this['@experimental']();
-    this['@since']();
-    this['@version']();
-    this['@todo']();
-    this['@ignore']();
-    this['@_pseudoExport']();
-    this['@_undocument']();
-    this['@_unknown']();
+    this._$kind();
+    this._$variation();
+    this._$name();
+    this._$memberof();
+    this._$member();
+    this._$content();
+    this._$generator();
 
-    this['@param']();
-    this['@property']();
-    this['@return']();
-    this['@type']();
-    this['@abstract']();
-    this['@override']();
-    this['@throws']();
-    this['@emits']();
-    this['@listens']();
-    this['@_member']();
-    this['@_content']();
-    this['@_generator']();
+    this._$static();
+    this._$longname();
+    this._$access();
+    this._$export();
+    this._$importPath();
+    this._$importStyle();
+    this._$desc();
+    this._$example();
+    this._$see();
+    this._$lineNumber();
+    this._$deprecated();
+    this._$experimental();
+    this._$since();
+    this._$version();
+    this._$todo();
+    this._$ignore();
+    this._$pseudoExport();
+    this._$undocument();
+    this._$unknown();
+    this._$param();
+    this._$property();
+    this._$return();
+    this._$type();
+    this._$abstract();
+    this._$override();
+    this._$throws();
+    this._$emits();
+    this._$listens();
   }
 
   /**
    * decide `kind`.
    * @abstract
    */
-  ['@_kind']() {}
+  _$kind() {}
 
   /** for @_variation */
   /**
@@ -90,42 +90,42 @@ export default class AbstractDoc {
    * @todo implements `@variation`.
    * @abstract
    */
-  ['@_variation']() {}
+  _$variation() {}
 
   /**
    * decide `name`
    * @abstract
    */
-  ['@_name']() {}
+  _$name() {}
 
   /**
    * decide `memberof`.
    * @abstract
    */
-  ['@_memberof']() {}
+  _$memberof() {}
 
   /**
    * decide `member`.
    * @abstract
    */
-  ['@_member']() {}
+  _$member() {}
 
   /**
    * decide `content`.
    * @abstract
    */
-  ['@_content']() {}
+  _$content() {}
 
   /**
    * decide `generator`.
    * @abstract
    */
-  ['@_generator']() {}
+  _$generator() {}
 
   /**
    * decide `static`.
    */
-  ['@_static']() {
+  _$static() {
     if ('static' in this._node) {
       this._value.static = this._node.static;
     } else {
@@ -136,7 +136,7 @@ export default class AbstractDoc {
   /**
    * decide `longname`.
    */
-  ['@_longname']() {
+  _$longname() {
     let memberof = this._value.memberof;
     let name = this._value.name;
     let scope = this._value.static ? '.' : '#';
@@ -151,7 +151,7 @@ export default class AbstractDoc {
    * decide `access`.
    * process also @public, @private and @protected.
    */
-  ['@access']() {
+  _$access() {
     let tag = this._find(['@access', '@public', '@private', '@protected']);
     if (tag) {
       let access;
@@ -171,22 +171,22 @@ export default class AbstractDoc {
   /**
    * avoid unknown tag.
    */
-  ['@public'](){}
+  _$public(){}
 
   /**
    * avoid unknown tag.
    */
-  ['@protected']() {}
+  _$protected() {}
 
   /**
    * avoid unknown tag.
    */
-  ['@private']() {}
+  _$private() {}
 
   /**
    * decide `export`.
    */
-  ['@_export']() {
+  _$export() {
     let parent = this._node.parent;
     while (parent) {
       if (parent.type === 'ExportDefaultDeclaration') {
@@ -206,14 +206,14 @@ export default class AbstractDoc {
   /**
    * decide `importPath`.
    */
-  ['@_importPath']() {
+  _$importPath() {
     this._value.importPath = this._pathResolver.importPath;
   }
 
   /**
    * decide `importStyle`.
    */
-  ['@_importStyle']() {
+  _$importStyle() {
     if (this._node.__esdoc__pseudo_export) {
       this._value.importStyle = null;
       return;
@@ -238,14 +238,14 @@ export default class AbstractDoc {
   /**
    * decide `description`.
    */
-  ['@desc']() {
+  _$desc() {
     this._value.description = this._findTagValue(['@desc']);
   }
 
   /**
    * decide `examples`.
    */
-  ['@example']() {
+  _$example() {
     let tags = this._findAll(['@example']);
     if (!tags) return;
     if (!tags.length) return;
@@ -259,7 +259,7 @@ export default class AbstractDoc {
   /**
    * decide `see`.
    */
-  ['@see']() {
+  _$see() {
     let tags = this._findAll(['@see']);
     if (!tags) return;
     if (!tags.length) return;
@@ -273,7 +273,7 @@ export default class AbstractDoc {
   /**
    * decide `lineNumber`.
    */
-  ["@_lineNumber"]() {
+  _$lineNumber() {
     let node = this._node;
     if (node.loc) {
       this._value.lineNumber = node.loc.start.line;
@@ -283,7 +283,7 @@ export default class AbstractDoc {
   /**
    * decide `deprecated`.
    */
-  ['@deprecated']() {
+  _$deprecated() {
     let tag = this._find(['@deprecated']);
     if (tag) {
       if (tag.tagValue) {
@@ -297,7 +297,7 @@ export default class AbstractDoc {
   /**
    * decide `experimental`.
    */
-  ['@experimental'](){
+  _$experimental(){
     let tag = this._find(['@experimental']);
     if (tag) {
       if (tag.tagValue) {
@@ -311,7 +311,7 @@ export default class AbstractDoc {
   /**
    * decide `since`.
    */
-  ['@since'](){
+  _$since(){
     let tag = this._find(['@since']);
     if (tag) {
       this._value.since = tag.tagValue;
@@ -321,7 +321,7 @@ export default class AbstractDoc {
   /**
    * decide `version`.
    */
-  ['@version'](){
+  _$version(){
     let tag = this._find(['@version']);
     if (tag) {
       this._value.version = tag.tagValue;
@@ -331,7 +331,7 @@ export default class AbstractDoc {
   /**
    * decide `todo`.
    */
-  ['@todo'](){
+  _$todo(){
     let tags = this._findAll(['@todo']);
     if (tags) {
       this._value.todo = [];
@@ -344,7 +344,7 @@ export default class AbstractDoc {
   /**
    * decide `ignore`.
    */
-  ['@ignore'](){
+  _$ignore(){
     let tag = this._find(['@ignore']);
     if (tag) {
       this._value.ignore = true;
@@ -354,7 +354,7 @@ export default class AbstractDoc {
   /**
    * decide `pseudoExport`.
    */
-  ['@_pseudoExport'](){
+  _$pseudoExport(){
     if (this._node.__esdoc__pseudo_export) {
       this._value.pseudoExport = true;
     }
@@ -363,7 +363,7 @@ export default class AbstractDoc {
   /**
    * decide `undocument` with internal tag.
    */
-  ['@_undocument']() {
+  _$undocument() {
     let tag = this._find(['@_undocument']);
     if (tag) {
       this._value.undocument = true;
@@ -373,9 +373,10 @@ export default class AbstractDoc {
   /**
    * decide `unknown`.
    */
-  ['@_unknown']() {
+  _$unknown() {
     for (let tag of this._commentTags) {
-      if (this[tag.tagName]) continue;
+      const methodName = tag.tagName.replace(/^[@]/, '_$');
+      if (this[methodName]) continue;
 
       if (!this._value.unknown) this._value.unknown = [];
       this._value.unknown.push(tag);
@@ -385,7 +386,7 @@ export default class AbstractDoc {
   /**
    * decide `param`.
    */
-  ['@param']() {
+  _$param() {
     let values = this._findAllTagValues(['@param']);
     if (!values) return;
 
@@ -404,7 +405,7 @@ export default class AbstractDoc {
   /**
    * decide `return`.
    */
-  ['@return']() {
+  _$return() {
     let value = this._findTagValue(['@return', '@returns']);
     if (!value) return;
 
@@ -416,7 +417,7 @@ export default class AbstractDoc {
   /**
    * decide `property`.
    */
-  ['@property']() {
+  _$property() {
     let values = this._findAllTagValues(['@property']);
     if (!values) return;
 
@@ -431,7 +432,7 @@ export default class AbstractDoc {
   /**
    * decide `type`.
    */
-  ['@type']() {
+  _$type() {
     let value = this._findTagValue(['@type']);
     if (!value) return;
 
@@ -443,7 +444,7 @@ export default class AbstractDoc {
   /**
    * decide `abstract`.
    */
-  ['@abstract']() {
+  _$abstract() {
     let tag = this._find(['@abstract']);
     if (tag) {
       this._value.abstract = true;
@@ -453,7 +454,7 @@ export default class AbstractDoc {
   /**
    * decide `override`.
    */
-  ['@override'](){
+  _$override(){
     let tag = this._find(['@override']);
     if (tag) {
       this._value.override = true;
@@ -463,7 +464,7 @@ export default class AbstractDoc {
   /**
    * decide `throws`.
    */
-  ['@throws'](){
+  _$throws(){
     let values = this._findAllTagValues(['@throws']);
     if (!values) return;
 
@@ -481,7 +482,7 @@ export default class AbstractDoc {
   /**
    * decide `emits`.
    */
-  ['@emits'](){
+  _$emits(){
     let values = this._findAllTagValues(['@emits']);
     if (!values) return;
 
@@ -499,7 +500,7 @@ export default class AbstractDoc {
   /**
    * decide `listens`.
    */
-  ['@listens'](){
+  _$listens(){
     let values = this._findAllTagValues(['@listens']);
     if (!values) return;
 

--- a/src/Doc/AbstractDoc.js
+++ b/src/Doc/AbstractDoc.js
@@ -84,17 +84,6 @@ export default class AbstractDoc {
    */
   ['@_kind']() {}
 
-  /**
-   * decide `static`.
-   */
-  ['@_static']() {
-    if ('static' in this._node) {
-      this._value.static = this._node.static;
-    } else {
-      this._value.static = true;
-    }
-  }
-
   /** for @_variation */
   /**
    * decide `variation`.
@@ -114,6 +103,35 @@ export default class AbstractDoc {
    * @abstract
    */
   ['@_memberof']() {}
+
+  /**
+   * decide `member`.
+   * @abstract
+   */
+  ['@_member']() {}
+
+  /**
+   * decide `content`.
+   * @abstract
+   */
+  ['@_content']() {}
+
+  /**
+   * decide `generator`.
+   * @abstract
+   */
+  ['@_generator']() {}
+
+  /**
+   * decide `static`.
+   */
+  ['@_static']() {
+    if ('static' in this._node) {
+      this._value.static = this._node.static;
+    } else {
+      this._value.static = true;
+    }
+  }
 
   /**
    * decide `longname`.
@@ -495,23 +513,6 @@ export default class AbstractDoc {
       });
     }
   }
-
-  /**
-   * decide `member`.
-   */
-  ['@_member']() {}
-
-  /**
-   * decide `content`.
-   * @abstract
-   */
-  ['@_content']() {}
-
-  /**
-   * decide `generator`.
-   * @abstract
-   */
-  ['@_generator']() {}
 
   /**
    * find all tags.

--- a/src/Doc/AssignmentDoc.js
+++ b/src/Doc/AssignmentDoc.js
@@ -1,4 +1,3 @@
-import Logger from 'color-logger';
 import AbstractDoc from './AbstractDoc.js';
 
 /**
@@ -10,8 +9,6 @@ export default class AssignmentDoc extends AbstractDoc {
    */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
-
     this._value.kind = 'variable';
   }
 
@@ -20,8 +17,6 @@ export default class AssignmentDoc extends AbstractDoc {
    */
   ['@_name']() {
     super['@_name']();
-    if (this._value.name) return;
-
     let name = this._flattenMemberExpression(this._node.left).replace(/^this\./, '');
     this._value.name = name;
   }
@@ -31,7 +26,6 @@ export default class AssignmentDoc extends AbstractDoc {
    */
   ['@_memberof']() {
     super['@_memberof']();
-    if (this._value.memberof) return;
     this._value.memberof = this._pathResolver.filePath;
   }
 }

--- a/src/Doc/AssignmentDoc.js
+++ b/src/Doc/AssignmentDoc.js
@@ -7,16 +7,16 @@ export default class AssignmentDoc extends AbstractDoc {
   /**
    * specify ``variable`` to kind.
    */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
     this._value.kind = 'variable';
   }
 
   /**
    * take out self name from self node.
    */
-  ['@_name']() {
-    super['@_name']();
+  _$name() {
+    super._$name();
     let name = this._flattenMemberExpression(this._node.left).replace(/^this\./, '');
     this._value.name = name;
   }
@@ -24,8 +24,8 @@ export default class AssignmentDoc extends AbstractDoc {
   /**
    * take out self memberof from file path.
    */
-  ['@_memberof']() {
-    super['@_memberof']();
+  _$memberof() {
+    super._$memberof();
     this._value.memberof = this._pathResolver.filePath;
   }
 }

--- a/src/Doc/ClassDoc.js
+++ b/src/Doc/ClassDoc.js
@@ -14,20 +14,20 @@ export default class ClassDoc extends AbstractDoc {
   _apply() {
     super._apply();
 
-    this['@interface']();
-    this['@extends']();
-    this['@implements']();
+    this._$interface();
+    this._$extends();
+    this._$implements();
   }
 
   /** specify ``class`` to kind. */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
     this._value.kind = 'class';
   }
 
   /** take out self name from self node */
-  ['@_name']() {
-    super['@_name']();
+  _$name() {
+    super._$name();
 
     if (this._node.id) {
       this._value.name = this._node.id.name;
@@ -37,13 +37,13 @@ export default class ClassDoc extends AbstractDoc {
   }
 
   /** take out self memberof from file path. */
-  ['@_memberof']() {
-    super['@_memberof']();
+  _$memberof() {
+    super._$memberof();
     this._value.memberof = this._pathResolver.filePath;
   }
 
   /** for @interface */
-  ['@interface']() {
+  _$interface() {
     let tag = this._find(['@interface']);
     if (tag) {
       this._value.interface = ['', 'true', true].includes(tag.tagValue);
@@ -53,7 +53,7 @@ export default class ClassDoc extends AbstractDoc {
   }
 
   /** for @extends, does not need to use this tag. */
-  ['@extends']() {
+  _$extends() {
     let values = this._findAllTagValues(['@extends', '@extend']);
     if (values) {
       this._value.extends = [];
@@ -106,7 +106,7 @@ export default class ClassDoc extends AbstractDoc {
   }
 
   /** for @implements */
-  ['@implements'](){
+  _$implements(){
     let values = this._findAllTagValues(['@implements', '@implement']);
     if (!values) return;
 

--- a/src/Doc/ClassDoc.js
+++ b/src/Doc/ClassDoc.js
@@ -22,14 +22,12 @@ export default class ClassDoc extends AbstractDoc {
   /** specify ``class`` to kind. */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
     this._value.kind = 'class';
   }
 
   /** take out self name from self node */
   ['@_name']() {
     super['@_name']();
-    if (this._value.name) return;
 
     if (this._node.id) {
       this._value.name = this._node.id.name;
@@ -41,7 +39,6 @@ export default class ClassDoc extends AbstractDoc {
   /** take out self memberof from file path. */
   ['@_memberof']() {
     super['@_memberof']();
-    if (this._value.memberof) return;
     this._value.memberof = this._pathResolver.filePath;
   }
 

--- a/src/Doc/ExternalDoc.js
+++ b/src/Doc/ExternalDoc.js
@@ -21,13 +21,13 @@ export default class ExternalDoc extends AbstractDoc {
   }
 
   /** specify ``external`` to kind. */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
     this._value.kind = 'external';
   }
 
   /** take out self name from tag */
-  ['@_name']() {
+  _$name() {
     let value = this._findTagValue(['@external']);
     if (!value) {
       logger.w(`can not resolve name.`);
@@ -53,19 +53,19 @@ export default class ExternalDoc extends AbstractDoc {
   }
 
   /** take out self memberof from file path. */
-  ['@_memberof']() {
-    super['@_memberof']();
+  _$memberof() {
+    super._$memberof();
     this._value.memberof = this._pathResolver.filePath;
   }
 
   /** specify name to longname */
-  ['@_longname']() {
-    super['@_longname']();
+  _$longname() {
+    super._$longname();
     if (this._value.longname) return;
     this._value.longname = this._value.name;
   }
 
   /** avoid unknown tag */
-  ['@external']() {}
+  _$external() {}
 }
 

--- a/src/Doc/ExternalDoc.js
+++ b/src/Doc/ExternalDoc.js
@@ -23,20 +23,19 @@ export default class ExternalDoc extends AbstractDoc {
   /** specify ``external`` to kind. */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
     this._value.kind = 'external';
   }
 
   /** take out self name from tag */
   ['@_name']() {
-    let value = this._findTagValue(['@_name', '@external']);
+    let value = this._findTagValue(['@external']);
     if (!value) {
       logger.w(`can not resolve name.`);
     }
 
     this._value.name = value;
 
-    let tags = this._findAll(['@_name', '@external']);
+    let tags = this._findAll(['@external']);
     if (!tags) {
       logger.w(`can not resolve name.`);
       return;
@@ -45,13 +44,9 @@ export default class ExternalDoc extends AbstractDoc {
     let name;
     for (let tag of tags) {
       let {tagName, tagValue} = tag;
-      if (tagName === '@_name') {
-        name = tagValue;
-      } else if (tagName === '@external') {
-        let {typeText, paramDesc} = ParamParser.parseParamValue(tagValue, true, false, true);
-        name = typeText;
-        this._value.externalLink = paramDesc;
-      }
+      let {typeText, paramDesc} = ParamParser.parseParamValue(tagValue, true, false, true);
+      name = typeText;
+      this._value.externalLink = paramDesc;
     }
 
     this._value.name = name;
@@ -60,7 +55,6 @@ export default class ExternalDoc extends AbstractDoc {
   /** take out self memberof from file path. */
   ['@_memberof']() {
     super['@_memberof']();
-    if (this._value.memberof) return;
     this._value.memberof = this._pathResolver.filePath;
   }
 
@@ -71,9 +65,7 @@ export default class ExternalDoc extends AbstractDoc {
     this._value.longname = this._value.name;
   }
 
-  /** for @external */
-  ['@external']() {
-    // avoid unknown tag.
-  }
+  /** avoid unknown tag */
+  ['@external']() {}
 }
 

--- a/src/Doc/FileDoc.js
+++ b/src/Doc/FileDoc.js
@@ -18,25 +18,25 @@ export default class FileDoc extends AbstractDoc {
   }
 
   /** specify ``file`` to kind. */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
     this._value.kind = 'file';
   }
 
   /** take out self name from file path */
-  ['@_name']() {
-    super['@_name']();
+  _$name() {
+    super._$name();
     this._value.name = this._pathResolver.filePath;
   }
 
   /** specify name to longname */
-  ['@_longname']() {
+  _$longname() {
     this._value.longname = this._value.name;
   }
 
   /** specify file content to value.content */
-  ['@_content']() {
-    super['@_content']();
+  _$content() {
+    super._$content();
 
     let filePath = this._pathResolver.fileFullPath;
     let content = fs.readFileSync(filePath, {encode: 'utf8'}).toString();

--- a/src/Doc/FileDoc.js
+++ b/src/Doc/FileDoc.js
@@ -20,31 +20,23 @@ export default class FileDoc extends AbstractDoc {
   /** specify ``file`` to kind. */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
     this._value.kind = 'file';
   }
 
   /** take out self name from file path */
   ['@_name']() {
     super['@_name']();
-    if (this._value.name) return;
     this._value.name = this._pathResolver.filePath;
   }
 
   /** specify name to longname */
   ['@_longname']() {
-    let value = this._findTagValue(['@_longname']);
-    if (value) {
-      this._value.longname = value;
-    } else {
-      this._value.longname = this._value.name;
-    }
+    this._value.longname = this._value.name;
   }
 
   /** specify file content to value.content */
   ['@_content']() {
     super['@_content']();
-    if ('content' in this._value) return;
 
     let filePath = this._pathResolver.fileFullPath;
     let content = fs.readFileSync(filePath, {encode: 'utf8'}).toString();

--- a/src/Doc/FunctionDoc.js
+++ b/src/Doc/FunctionDoc.js
@@ -8,14 +8,14 @@ import ASTUtil from '../Util/ASTUtil.js';
  */
 export default class FunctionDoc extends AbstractDoc {
   /** specify ``function`` to kind. */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
     this._value.kind = 'function';
   }
 
   /** take out self name from self node */
-  ['@_name']() {
-    super['@_name']();
+  _$name() {
+    super._$name();
 
     if (this._node.id) {
       if (this._node.id.type === 'MemberExpression') {
@@ -29,28 +29,28 @@ export default class FunctionDoc extends AbstractDoc {
   }
 
   /** take out self name from file path */
-  ['@_memberof']() {
-    super['@_memberof']();
+  _$memberof() {
+    super._$memberof();
     this._value.memberof = this._pathResolver.filePath;
   }
 
   /** check generator property in self node */
-  ['@_generator']() {
-    super['@_generator']();
+  _$generator() {
+    super._$generator();
     this._value.generator = this._node.generator;
   }
 
   /** if @param is not exists, guess type of param by using self node. */
-  ['@param']() {
-    super['@param']();
+  _$param() {
+    super._$param();
     if (this._value.params) return;
 
     this._value.params = ParamParser.guessParams(this._node.params);
   }
 
   /** if @return is not exists, guess type of return by using self node. */
-  ['@return']() {
-    super['@return']();
+  _$return() {
+    super._$return();
     if (this._value.return) return;
 
     let result = ParamParser.guessReturnParam(this._node.body);

--- a/src/Doc/FunctionDoc.js
+++ b/src/Doc/FunctionDoc.js
@@ -10,14 +10,12 @@ export default class FunctionDoc extends AbstractDoc {
   /** specify ``function`` to kind. */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
     this._value.kind = 'function';
   }
 
   /** take out self name from self node */
   ['@_name']() {
     super['@_name']();
-    if (this._value.name) return;
 
     if (this._node.id) {
       if (this._node.id.type === 'MemberExpression') {
@@ -33,15 +31,12 @@ export default class FunctionDoc extends AbstractDoc {
   /** take out self name from file path */
   ['@_memberof']() {
     super['@_memberof']();
-    if (this._value.memberof) return;
     this._value.memberof = this._pathResolver.filePath;
   }
 
   /** check generator property in self node */
   ['@_generator']() {
     super['@_generator']();
-    if ('generator' in this._value) return;
-
     this._value.generator = this._node.generator;
   }
 

--- a/src/Doc/FunctionDoc.js
+++ b/src/Doc/FunctionDoc.js
@@ -19,7 +19,8 @@ export default class FunctionDoc extends AbstractDoc {
 
     if (this._node.id) {
       if (this._node.id.type === 'MemberExpression') {
-        this._value.name = ASTUtil.flattenMemberExpression(this._node.id);
+        // todo: can not reproduce this condition.
+        // this._value.name = ASTUtil.flattenMemberExpression(this._node.id);
       } else {
         this._value.name = this._node.id.name;
       }

--- a/src/Doc/MemberDoc.js
+++ b/src/Doc/MemberDoc.js
@@ -20,13 +20,13 @@ export default class MemberDoc extends AbstractDoc {
   }
 
   /** specify ``member`` to kind. */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
     this._value.kind = 'member';
   }
 
   /** use static property in class */
-  ['@_static']() {
+  _$static() {
     let parent = this._node.parent;
     while (parent) {
       if (parent.type === 'ClassMethod') {
@@ -38,7 +38,7 @@ export default class MemberDoc extends AbstractDoc {
   }
 
   /** take out self name from self node */
-  ['@_name']() {
+  _$name() {
     let name;
     if (this._node.left.computed) {
       const expression = babelGenerator(this._node.left.property).code.replace(/^this/, '');
@@ -50,13 +50,13 @@ export default class MemberDoc extends AbstractDoc {
   }
 
   /** borrow {@link MethodDoc#@_memberof} */
-  ['@_memberof']() {
-    MethodDoc.prototype['@_memberof'].call(this);
+  _$memberof() {
+    MethodDoc.prototype._$memberof.call(this);
   }
 
   /** if @type is not exists, guess type by using self node */
-  ['@type']() {
-    super['@type']();
+  _$type() {
+    super._$type();
     if (this._value.type) return;
 
     this._value.type = ParamParser.guessType(this._node.right);

--- a/src/Doc/MemberDoc.js
+++ b/src/Doc/MemberDoc.js
@@ -22,19 +22,11 @@ export default class MemberDoc extends AbstractDoc {
   /** specify ``member`` to kind. */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
     this._value.kind = 'member';
   }
 
   /** use static property in class */
   ['@_static']() {
-    let tag = this._find(['@_static']);
-    if (tag) {
-      let value = ['', 'true', true].includes(tag.tagValue);
-      this._value.static = value;
-      return;
-    }
-
     let parent = this._node.parent;
     while (parent) {
       if (parent.type === 'ClassMethod') {
@@ -48,27 +40,12 @@ export default class MemberDoc extends AbstractDoc {
   /** take out self name from self node */
   ['@_name']() {
     let name;
-    let tags = this._findAll(['@_name', '@_member']);
-    if (tags) {
-      for (let tag of tags) {
-        let {tagName, tagValue} = tag;
-        if (tagName === '@_name') {
-          name = tagValue;
-        } else if (tagName === '@_member') {
-          let {paramName} = ParamParser.parseParamValue(tagValue, true, true, false);
-          name = paramName;
-        }
-      }
-
+    if (this._node.left.computed) {
+      const expression = babelGenerator(this._node.left.property).code.replace(/^this/, '');
+      name = `[${expression}]`;
     } else {
-      if (this._node.left.computed) {
-        const expression = babelGenerator(this._node.left.property).code.replace(/^this/, '');
-        name = `[${expression}]`;
-      } else {
-        name = this._flattenMemberExpression(this._node.left).replace(/^this\./, '');
-      }
+      name = this._flattenMemberExpression(this._node.left).replace(/^this\./, '');
     }
-
     this._value.name = name;
   }
 

--- a/src/Doc/MethodDoc.js
+++ b/src/Doc/MethodDoc.js
@@ -20,15 +20,13 @@ export default class MethodDoc extends AbstractDoc {
 
   /** use kind property of self node. */
   ['@_kind']() {
-    AbstractDoc.prototype['@_kind'].call(this);
-    if (this._value.kind) return;
+    super['@_kind']();
     this._value.kind = this._node.kind;
   }
 
   /** take out self name from self node */
   ['@_name']() {
-    AbstractDoc.prototype['@_name'].call(this);
-    if (this._value.name) return;
+    super['@_name']();
 
     if (this._node.computed) {
       const expression = babelGenerator(this._node.key).code;
@@ -40,8 +38,7 @@ export default class MethodDoc extends AbstractDoc {
 
   /** take out memberof from parent class node */
   ['@_memberof']() {
-    AbstractDoc.prototype['@_memberof'].call(this);
-    if (this._value.memberof) return;
+    super['@_memberof']();
 
     let memberof;
     let parent = this._node.parent;
@@ -97,7 +94,6 @@ export default class MethodDoc extends AbstractDoc {
   /** use generator property of self node. */
   ['@_generator']() {
     super['@_generator']();
-    if ('generator' in this._value) return;
 
     this._value.generator = this._node.generator;
   }

--- a/src/Doc/MethodDoc.js
+++ b/src/Doc/MethodDoc.js
@@ -19,14 +19,14 @@ export default class MethodDoc extends AbstractDoc {
   }
 
   /** use kind property of self node. */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
     this._value.kind = this._node.kind;
   }
 
   /** take out self name from self node */
-  ['@_name']() {
-    super['@_name']();
+  _$name() {
+    super._$name();
 
     if (this._node.computed) {
       const expression = babelGenerator(this._node.key).code;
@@ -37,8 +37,8 @@ export default class MethodDoc extends AbstractDoc {
   }
 
   /** take out memberof from parent class node */
-  ['@_memberof']() {
-    super['@_memberof']();
+  _$memberof() {
+    super._$memberof();
 
     let memberof;
     let parent = this._node.parent;
@@ -53,8 +53,8 @@ export default class MethodDoc extends AbstractDoc {
   }
 
   /** if @param is not exists, guess type of param by using self node. but ``get`` and ``set`` are not guessed. */
-  ['@param']() {
-    super['@param']();
+  _$param() {
+    super._$param();
     if (this._value.params) return;
 
     if (['set', 'get'].includes(this._value.kind)) return;
@@ -63,8 +63,8 @@ export default class MethodDoc extends AbstractDoc {
   }
 
   /** if @type is not exists, guess type by using self node. only ``get`` and ``set`` are guess. */
-  ['@type']() {
-    super['@type']();
+  _$type() {
+    super._$type();
     if (this._value.type) return;
 
     switch (this._value.kind) {
@@ -79,8 +79,8 @@ export default class MethodDoc extends AbstractDoc {
   }
 
   /** if @return is not exists, guess type of return by usigin self node. but ``constructor``, ``get`` and ``set``are not guessed. */
-  ['@return']() {
-    super['@return']();
+  _$return() {
+    super._$return();
     if (this._value.return) return;
 
     if (['constructor', 'set', 'get'].includes(this._value.kind)) return;
@@ -92,8 +92,8 @@ export default class MethodDoc extends AbstractDoc {
   }
 
   /** use generator property of self node. */
-  ['@_generator']() {
-    super['@_generator']();
+  _$generator() {
+    super._$generator();
 
     this._value.generator = this._node.generator;
   }

--- a/src/Doc/TestDoc.js
+++ b/src/Doc/TestDoc.js
@@ -22,7 +22,6 @@ export default class TestDoc extends AbstractDoc {
   /** use name property of self node. */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
 
     switch (this._node.callee.name) {
       case 'suite': //fall
@@ -42,7 +41,6 @@ export default class TestDoc extends AbstractDoc {
   /** set name and testId from special esdoc property. */
   ['@_name']() {
     super['@_name']();
-    if (this._value.name) return;
 
     this._value.name = this._node._esdocTestName;
     this._value.testId = this._node._esdocTestId;
@@ -51,7 +49,6 @@ export default class TestDoc extends AbstractDoc {
   /** set memberof to use parent test nod and file path. */
   ['@_memberof']() {
     super['@_memberof']();
-    if (this._value.memberof) return;
 
     let chain = [];
     let parent = this._node.parent;

--- a/src/Doc/TestDoc.js
+++ b/src/Doc/TestDoc.js
@@ -12,7 +12,7 @@ export default class TestDoc extends AbstractDoc {
   _apply() {
     super._apply();
 
-    this['@testTarget']();
+    this._$testTarget();
 
     delete this._value.export;
     delete this._value.importPath;
@@ -20,8 +20,8 @@ export default class TestDoc extends AbstractDoc {
   }
 
   /** use name property of self node. */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
 
     switch (this._node.callee.name) {
       case 'suite': //fall
@@ -39,16 +39,16 @@ export default class TestDoc extends AbstractDoc {
   }
 
   /** set name and testId from special esdoc property. */
-  ['@_name']() {
-    super['@_name']();
+  _$name() {
+    super._$name();
 
     this._value.name = this._node._esdocTestName;
     this._value.testId = this._node._esdocTestId;
   }
 
   /** set memberof to use parent test nod and file path. */
-  ['@_memberof']() {
-    super['@_memberof']();
+  _$memberof() {
+    super._$memberof();
 
     let chain = [];
     let parent = this._node.parent;
@@ -69,15 +69,15 @@ export default class TestDoc extends AbstractDoc {
   }
 
   /** set describe by using test node arguments. */
-  ['@desc']() {
-    super['@desc']();
+  _$desc() {
+    super._$desc();
     if (this._value.description) return;
 
     this._value.description = this._node.arguments[0].value;
   }
 
   /** for @testTarget. */
-  ['@testTarget']() {
+  _$testTarget() {
     let values = this._findAllTagValues(['@test', '@testTarget']);
     if (!values) return;
 

--- a/src/Doc/TestFileDoc.js
+++ b/src/Doc/TestFileDoc.js
@@ -5,7 +5,7 @@ import FileDoc from './FileDoc.js';
  */
 export default class TestFileDoc extends FileDoc {
   /** set ``testFile`` to kind. */
-  ['@_kind']() {
+  _$kind() {
     this._value.kind = 'testFile';
   }
 }

--- a/src/Doc/TypedefDoc.js
+++ b/src/Doc/TypedefDoc.js
@@ -15,7 +15,7 @@ export default class TypedefDoc extends AbstractDoc {
   _apply() {
     super._apply();
 
-    this['@typedef']();
+    this._$typedef();
 
     delete this._value.export;
     delete this._value.importPath;
@@ -23,14 +23,13 @@ export default class TypedefDoc extends AbstractDoc {
   }
 
   /** specify ``typedef`` to kind. */
-  ['@_kind']() {
-    super['@_kind']();
-    // if (this._value.kind) return;
+  _$kind() {
+    super._$kind();
     this._value.kind = 'typedef';
   }
 
   /** set name by using tag. */
-  ['@_name']() {
+  _$name() {
     let tags = this._findAll(['@typedef']);
     if (!tags) {
       logger.w(`can not resolve name.`);
@@ -48,8 +47,8 @@ export default class TypedefDoc extends AbstractDoc {
   }
 
   /** set memberof by using file path. */
-  ['@_memberof']() {
-    super['@_memberof']();
+  _$memberof() {
+    super._$memberof();
 
     let memberof;
     let parent = this._node.parent;
@@ -66,7 +65,7 @@ export default class TypedefDoc extends AbstractDoc {
   }
 
   /** for @typedef */
-  ['@typedef']() {
+  _$typedef() {
     let value = this._findTagValue(['@typedef']);
     if (!value) return;
 

--- a/src/Doc/TypedefDoc.js
+++ b/src/Doc/TypedefDoc.js
@@ -25,13 +25,13 @@ export default class TypedefDoc extends AbstractDoc {
   /** specify ``typedef`` to kind. */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
+    // if (this._value.kind) return;
     this._value.kind = 'typedef';
   }
 
   /** set name by using tag. */
   ['@_name']() {
-    let tags = this._findAll(['@_name', '@typedef']);
+    let tags = this._findAll(['@typedef']);
     if (!tags) {
       logger.w(`can not resolve name.`);
       return;
@@ -40,12 +40,8 @@ export default class TypedefDoc extends AbstractDoc {
     let name;
     for (let tag of tags) {
       let {tagName, tagValue} = tag;
-      if (tagName === '@_name') {
-        name = tagValue;
-      } else if (tagName === '@typedef') {
-        let {typeText, paramName, paramDesc} = ParamParser.parseParamValue(tagValue, true, true, false);
-        name = paramName;
-      }
+      let {typeText, paramName, paramDesc} = ParamParser.parseParamValue(tagValue, true, true, false);
+      name = paramName;
     }
 
     this._value.name = name;
@@ -54,7 +50,6 @@ export default class TypedefDoc extends AbstractDoc {
   /** set memberof by using file path. */
   ['@_memberof']() {
     super['@_memberof']();
-    if (this._value.memberof) return;
 
     let memberof;
     let parent = this._node.parent;

--- a/src/Doc/VariableDoc.js
+++ b/src/Doc/VariableDoc.js
@@ -7,14 +7,14 @@ import ASTUtil from '../Util/ASTUtil.js';
  */
 export default class VariableDoc extends AbstractDoc {
   /** specify ``variable`` to kind. */
-  ['@_kind']() {
-    super['@_kind']();
+  _$kind() {
+    super._$kind();
     this._value.kind = 'variable';
   }
 
   /** set name by using self node. */
-  ['@_name']() {
-    super['@_name']();
+  _$name() {
+    super._$name();
 
     switch (this._node.declarations[0].id.type) {
       case 'Identifier':
@@ -32,15 +32,14 @@ export default class VariableDoc extends AbstractDoc {
   }
 
   /** set memberof by using file path. */
-  ['@_memberof']() {
-    super['@_memberof']();
-    // if (this._value.memberof) return;
+  _$memberof() {
+    super._$memberof();
     this._value.memberof = this._pathResolver.filePath;
   }
 
   /** if @type is not exists, guess type by using self node. */
-  ['@type']() {
-    super['@type']();
+  _$type() {
+    super._$type();
     if (this._value.type) return;
 
     if (this._node.declarations[0].init.type === 'NewExpression') {

--- a/src/Doc/VariableDoc.js
+++ b/src/Doc/VariableDoc.js
@@ -9,15 +9,12 @@ export default class VariableDoc extends AbstractDoc {
   /** specify ``variable`` to kind. */
   ['@_kind']() {
     super['@_kind']();
-    if (this._value.kind) return;
-
     this._value.kind = 'variable';
   }
 
   /** set name by using self node. */
   ['@_name']() {
     super['@_name']();
-    if (this._value.name) return;
 
     switch (this._node.declarations[0].id.type) {
       case 'Identifier':
@@ -37,7 +34,7 @@ export default class VariableDoc extends AbstractDoc {
   /** set memberof by using file path. */
   ['@_memberof']() {
     super['@_memberof']();
-    if (this._value.memberof) return;
+    // if (this._value.memberof) return;
     this._value.memberof = this._pathResolver.filePath;
   }
 

--- a/src/Factory/DocFactory.js
+++ b/src/Factory/DocFactory.js
@@ -397,11 +397,6 @@ export default class DocFactory {
     for (let tag of tags) {
       let tagName = tag.tagName;
       switch (tagName) {
-        case '@_class':    type = 'Class'; break;
-        case '@_member':   type = 'Member'; break;
-        case '@_method':   type = 'Method'; break;
-        case '@_function': type = 'Function'; break;
-        case '@_var':      type = 'Variable'; break;
         case '@typedef':  type = 'Typedef'; break;
         case '@external': type = 'External'; break;
       }

--- a/src/Util/ASTUtil.js
+++ b/src/Util/ASTUtil.js
@@ -153,23 +153,23 @@ export default class ASTUtil {
     return node;
   }
 
-  /**
-   * flatten name of MemberExpression.
-   * @param {ASTNode} memberExpression - MemberExpression Node.
-   * @returns {string} flatten node name.
-   */
-  static flattenMemberExpression(memberExpression) {
-    const names = [];
-    let object = memberExpression;
-    while (object) {
-      if (object.name) {
-        names.push(object.name);
-        break;
-      } else {
-        names.push(object.property.name);
-        object = object.object;
-      }
-    }
-    return names.reverse().join('.');
-  }
+  // /**
+  //  * flatten name of MemberExpression.
+  //  * @param {ASTNode} memberExpression - MemberExpression Node.
+  //  * @returns {string} flatten node name.
+  //  */
+  // static flattenMemberExpression(memberExpression) {
+  //   const names = [];
+  //   let object = memberExpression;
+  //   while (object) {
+  //     if (object.name) {
+  //       names.push(object.name);
+  //       break;
+  //     } else {
+  //       names.push(object.property.name);
+  //       object = object.object;
+  //     }
+  //   }
+  //   return names.reverse().join('.');
+  // }
 }

--- a/src/Util/ASTUtil.js
+++ b/src/Util/ASTUtil.js
@@ -26,7 +26,7 @@ export default class ASTUtil {
     babelTraverse(ast, {
       noScope: true,
       enter: function(path){
-        callback.call(this, path.node, path.parent);
+        callback.call(path, path.node, path.parent);
       }
     });
   }


### PR DESCRIPTION
# Overview
- remove internal private tag (aka `@_foo`)
- naming rule for tags to methods
  - before: `['@foo'](){}`
  - after: `_$foo(){}`