### PR TITLE
Fix crash with guessing return type

### DIFF
--- a/src/Parser/ParamParser.js
+++ b/src/Parser/ParamParser.js
@@ -384,6 +384,8 @@ export default class ParamParser {
           case 'ObjectMethod':
             typeMap[name] = 'function';
             break;
+          case 'SpreadProperty':
+            return {types: ['*']};
           default:
             typeMap[name] = '*';
         }

--- a/src/Parser/ParamParser.js
+++ b/src/Parser/ParamParser.js
@@ -376,6 +376,10 @@ export default class ParamParser {
     if (right.type === 'ObjectExpression') {
       const typeMap = {};
       for (const prop of right.properties) {
+        // Can't guess whats in spread object for now
+        if (prop.type === 'SpreadProperty') {
+          return {types: ['*']};
+        }
         const name = prop.key.name || prop.key.value;
         switch (prop.type) {
           case 'ObjectProperty':
@@ -384,8 +388,6 @@ export default class ParamParser {
           case 'ObjectMethod':
             typeMap[name] = 'function';
             break;
-          case 'SpreadProperty':
-            return {types: ['*']};
           default:
             typeMap[name] = '*';
         }

--- a/test/fixture/package/src/Guess/Return.js
+++ b/test/fixture/package/src/Guess/Return.js
@@ -19,7 +19,7 @@ export default class TestGuessReturn {
   }
 
   method5(){
-    const obj = {}
-    return {...obj}
+    const obj = {};
+    return {...obj};
   }
 }

--- a/test/fixture/package/src/Guess/Return.js
+++ b/test/fixture/package/src/Guess/Return.js
@@ -17,4 +17,9 @@ export default class TestGuessReturn {
   method4(){
     return `text`;
   }
+
+  method5(){
+    const obj = {}
+    return {...obj}
+  }
 }

--- a/test/src/HTMLTest/CoverageTest/CoverageTest.js
+++ b/test/src/HTMLTest/CoverageTest/CoverageTest.js
@@ -9,7 +9,7 @@ describe('test coverage', ()=> {
   it('has coverage summary', ()=> {
     assert(badge.includes('79%'));
     assert.includes(doc, '[data-ice="coverageBadge"]', './badge.svg', 'src');
-    assert.includes(doc, '[data-ice="totalCoverageCount"]', '280/350');
+    assert.includes(doc, '[data-ice="totalCoverageCount"]', '280/351');
     assert.equal(doc.find('[data-ice="file"] [data-ice="coverage"]').length, 119);
   });
 

--- a/test/src/HTMLTest/CoverageTest/CoverageTest.js
+++ b/test/src/HTMLTest/CoverageTest/CoverageTest.js
@@ -7,7 +7,7 @@ describe('test coverage', ()=> {
   const badge = fs.readFileSync('./test/fixture/dest/esdoc/badge.svg', {encoding: 'utf8'}).toString();
 
   it('has coverage summary', ()=> {
-    assert(badge.includes('80%'));
+    assert(badge.includes('79%'));
     assert.includes(doc, '[data-ice="coverageBadge"]', './badge.svg', 'src');
     assert.includes(doc, '[data-ice="totalCoverageCount"]', '280/350');
     assert.equal(doc.find('[data-ice="file"] [data-ice="coverage"]').length, 119);
@@ -86,7 +86,7 @@ describe('test coverage', ()=> {
     test('file/src/Generator/Method.js.html', '100 %2/2');
     test('file/src/Guess/Param.js.html#errorLines=11,13,15,17,19,21,23,5,7,9', '9 %1/11');
     test('file/src/Guess/Property.js.html#errorLines=10,12,5,6,8', '16 %1/6');
-    test('file/src/Guess/Return.js.html#errorLines=13,17,5,9', '20 %1/5');
+    test('file/src/Guess/Return.js.html#errorLines=13,17,21,5,9', '16 %1/6');
     test('file/src/Guess/Variable.js.html#errorLines=1,3,5,7', '0 %0/4');
     test('file/src/Ignore/Class.js.html', '100 %2/2');
     test('file/src/Ignore/Function.js.html', '-');


### PR DESCRIPTION
Minimal sample to reproduce crash:
```javascript
function noReturnDocTag() {
  const o = {};
  return { ...o };
}
```

Esdoc try to guess function return type when not `@return` tag found. When return type is Object, most times it can determine it's shape from AST. But when this object contains rest spread operator, it became compicated (for ex `return { ...obj }`, theorethically we can try track deeper and determine shape of `obj`, but for now we simple break guessing with `*`). In any case, this commit fixed crash with this case, because when AST node contain object with type `SpreadProperty`, it of course has no `key`.