### PR TITLE
Fix error when destructuring arrays with empty variable

### DIFF
--- a/src/Parser/ParamParser.js
+++ b/src/Parser/ParamParser.js
@@ -284,7 +284,7 @@ export default class ParamParser {
           const raw = [];
 
           for (const element of param.elements) {
-            if (element.type === 'Identifier') {
+            if (element === null || element.type === 'Identifier') {
               raw.push('null');
             } else if (element.type === 'AssignmentPattern') {
               if ('value' in element.right) {


### PR DESCRIPTION
When destructuring arguments from an array, this would throw an error "cannot read property type of 'null'":

function test([, v]) {
}
