### PR TITLE
add parserPlugins config opt to parse flow syntax

### DIFF
--- a/site/manual/configuration/config.md
+++ b/site/manual/configuration/config.md
@@ -6,6 +6,7 @@ ESDoc config example files.
 - [Integrate Test Codes Config](#integrate-test-codes-config)
 - [Integrate Manual Config](#integrate-manual-config)
 - [Use ECMAScript Proposal](#use-ecmascript-proposal)
+- [Additional Babylon parser plugins (Flow, etc.)](#additional-babylon-parser-plugins-flow-etc)
 - [Full Config](#full-config)
 
 ## Minimum Config
@@ -79,6 +80,26 @@ describe('MyClass has foo bar feature', ()=>{
 }
 ```
 
+## Additional Babylon parser plugins (Flow, etc.)
+
+Additional [Babylon Plugins][] like [Flow][] can be enabled by setting the
+`parserPlugins` config option to an array of strings:
+
+```json
+{
+  "source": "./src",
+  "destination": "./doc",
+  "parserPlugins": [
+    "flow"
+  ]
+}
+```
+
+The `JSX` plugin is included by default.
+
+[Babylon Plugins]: https://github.com/babel/babylon#plugins
+[Flow]: https://flowtype.org/
+
 ## Full Config
 ```json
 {
@@ -132,7 +153,10 @@ describe('MyClass has foo bar feature', ()=>{
     "asyncGenerators": true,
     "exportExtensions": true,
     "dynamicImport": true
-  }
+  },
+  "parserPlugins": [
+    "flow"
+  ]
 }
 ```
 
@@ -187,6 +211,6 @@ describe('MyClass has foo bar feature', ()=>{
 | ``experimentalProposal.asyncGenerators`` | - | false | If specify true, enable [Async Generators](http://babeljs.io/docs/plugins/transform-async-generator-functions/)(Babel). |
 | ``experimentalProposal.exportExtensions`` | - | false | If specify true, enable [Export Extensions](http://babeljs.io/docs/plugins/transform-export-extensions/)(Babel). |
 | ``experimentalProposal.dynamicImport`` | - | false | If specify true, enable [Dynamic Import](http://babeljs.io/docs/plugins/syntax-dynamic-import/)(Babel). |
-
+| ``parserPlugins`` | - | null | Optional array of string plugin names like ["flow"](https://babeljs.io/docs/plugins/syntax-flow/) to add to the Babylon parser |
 
 Note: A file path in config is based on current directory.

--- a/src/Parser/ESParser.js
+++ b/src/Parser/ESParser.js
@@ -71,6 +71,12 @@ export default class ESParser {
       if (experimental.exportExtensions) option.plugins.push('exportExtensions');
       if (experimental.dynamicImport) option.plugins.push('dynamicImport');
     }
+    
+    if (config.parserPlugins) {
+      config.parserPlugins.forEach((plugin) => {
+        option.plugins.push(plugin);
+      });
+    }
 
     return option;
   }

--- a/test/fixture/syntax/Flow.js
+++ b/test/fixture/syntax/Flow.js
@@ -1,0 +1,4 @@
+type Point = {
+  x: number,
+  y: number,
+};

--- a/test/src/ParserTest/ESParserTest.js
+++ b/test/src/ParserTest/ESParserTest.js
@@ -32,4 +32,9 @@ describe('ESParser', ()=>{
     const ast = ESParser.parse({experimentalProposal: {dynamicImport: true}}, './test/fixture/syntax/DynamicImport.js');
     assert(ast.program.sourceType === 'module');
   });
+  
+  it('can parse "flow"', ()=>{
+    const ast = ESParser.parse({parserPlugins: ['flow']}, './test/fixture/syntax/Flow.js');
+    assert(ast.program.sourceType === 'module');
+  });
 });


### PR DESCRIPTION
-   added a `parserPlugins` config option that can be set to an
    array of string plugin names to pass to Babylon, allowing
    ESDoc to parse Flow syntax (and whatever else might be
    available now / in the future).
-   added a parser test for the most basic flow syntax and tested
    on a project using flow.
-   added some documentation regarding the config option.