### PR TITLE
fix(parser): support parsing expressions in extend clause

### DIFF
--- a/src/Doc/AbstractDoc.js
+++ b/src/Doc/AbstractDoc.js
@@ -660,6 +660,9 @@ export default class AbstractDoc {
       } else if (target.type === 'Identifier') {
         results.push(target.name);
         break;
+      } else if (target.type === 'CallExpression') {
+        results.push(target.callee.name);
+        break;
       } else {
         results.push(target.property.name);
         target = target.object;


### PR DESCRIPTION
Currently esdoc fails for code containing a call expression in 'extends' clauses which is a supported feature and is popular with mixins.

Failing code:
```
function mix() {
	return {
		with: function () {
			return class { };
		}
	};
}
class Test extends mix().with() { }
```
