### PR TITLE
bugfix(comments): Escapes @ symbols in code blocks

### DIFF
--- a/src/Parser/CommentParser.js
+++ b/src/Parser/CommentParser.js
@@ -28,6 +28,7 @@ export default class CommentParser {
     comment = comment.replace(/^\*[\t ]?/gm, ''); // remove line head '*'
     if (comment.charAt(0) !== '@') comment = `@desc ${comment}`; // auto insert @desc
     comment = comment.replace(/[\t ]*$/, ''); // remove tail space.
+    comment = comment.replace(/```[\s\S]*?```/g, (match) => match.replace(/@/g, '\\ESCAPED_AT\\')); // escape code in descriptions
     comment = comment.replace(/^[\t ]*(@\w+)$/gm, '$1 \\TRUE'); // auto insert tag text to non-text tag (e.g. @interface)
     comment = comment.replace(/^[\t ]*(@\w+)[\t ](.*)/gm, '\\Z$1\\Z$2'); // insert separator (\\Z@tag\\Ztext)
     const lines = comment.split('\\Z');
@@ -46,7 +47,7 @@ export default class CommentParser {
           tagValue = nextLine;
           i++;
         }
-        tagValue = tagValue.replace('\\TRUE', '').replace(/^\n/, '').replace(/\n*$/, '');
+        tagValue = tagValue.replace('\\TRUE', '').replace(/\\ESCAPED_AT\\/g, '@').replace(/^\n/, '').replace(/\n*$/, '');
         tags.push({tagName, tagValue});
       }
     }


### PR DESCRIPTION
@ symbols inside code blocks are currently mistakenly interpreted as tags, making it difficult to have code examples for decorators. This PR escapes them, rather naively. Willing to try to do a better fix, but since this code is marked for refactor I figure @h13i32maru has plans for it anyways.