### PR TITLE
fixes #406 - allow config to disable ast json generation

### DIFF
--- a/src/ESDoc.js
+++ b/src/ESDoc.js
@@ -77,8 +77,9 @@ export default class ESDoc {
       const temp = this._traverse(config.source, filePath, packageName, mainFilePath);
       if (!temp) return;
       results.push(...temp.results);
-
-      asts.push({filePath: `source${path.sep}${relativeFilePath}`, ast: temp.ast});
+      if (config.outputAST) {
+        asts.push({filePath: `source${path.sep}${relativeFilePath}`, ast: temp.ast});
+      }
     });
 
     // config.index
@@ -101,7 +102,7 @@ export default class ESDoc {
       fs.outputFileSync(dumpPath, JSON.stringify(results, null, 2));
     }
 
-    // ast
+    // ast, array will be empty if config.outputAST is false - resulting in skipping the loop
     for (const ast of asts) {
       const json = JSON.stringify(ast.ast, null, 2);
       const filePath = path.resolve(config.destination, `ast/${ast.filePath}.json`);
@@ -162,6 +163,8 @@ export default class ESDoc {
     if (!config.index) config.index = './README.md';
 
     if (!config.package) config.package = './package.json';
+
+    if (typeof config.outputAST === 'undefined') config.outputAST = true;
   }
 
   /**

--- a/src/Typedef/typedef.js
+++ b/src/Typedef/typedef.js
@@ -13,6 +13,7 @@
  * @property {boolean} [undocumentIdentifier=true]
  * @property {boolean} [coverage=true]
  * @property {boolean} [debug=false]
+ * @property {boolean} [outputAST=true]
  * @property {string} [index="./README.md"]
  * @property {string} [package="./package.json"]
  * @property {string[]} [styles=[]]

--- a/test/integration-test/esdoc.json
+++ b/test/integration-test/esdoc.json
@@ -4,6 +4,7 @@
   "excludes": [".test.js$", "_Misc/Exclude.js$"],
   "index": "./test/integration-test/README.md",
   "package": "./test/integration-test/package.json",
+  "outputAST": false,
   "plugins": [
     {"name": "./test/integration-test/plugin/MyPlugin1.js", "option": {"enable": true}},
     {"name": "./test/integration-test/plugin/MyPlugin2.js", "option": {"enable": true}}

--- a/test/integration-test/src/_Misc/outputAST.test.js
+++ b/test/integration-test/src/_Misc/outputAST.test.js
@@ -1,0 +1,10 @@
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+
+describe('config outputAST:', ()=>{
+  it('does not generate AST', ()=>{
+    const outDir = fs.readdirSync(path.resolve(__dirname, '../../out'));
+    assert(outDir.includes('ast') === false)
+  });
+});


### PR DESCRIPTION
Per the request of @h13i32maru 

* `config.outputAST` is true by default
* if `config.outputAST` is true - ast is generated, otherwise skipped
* fixes #406 if user is made aware to set config.outputAST to false.

