### PR TITLE
check if README.md exists before attempting to read it

### DIFF
--- a/src/ESDoc.js
+++ b/src/ESDoc.js
@@ -228,7 +228,10 @@ export default class ESDoc {
    * @private
    */
   static _generateForIndex(config) {
-    const indexContent = fs.readFileSync(config.index, {encode: 'utf8'}).toString();
+    let indexContent = "";
+    if (fs.existsSync(config.index)) {
+      indexContent = fs.readFileSync(config.index, {encode: 'utf8'}).toString();
+    }
     const tag = {
       kind: 'index',
       content: indexContent,


### PR DESCRIPTION
### Problem
This PR addresses https://github.com/esdoc/esdoc/issues/432, a bug where esdoc fails to run if a `README.md` file is not present at the root of a given project. The bug occurs because the default behaviour of esdoc is to attempt to read that file regardless of whether or not it exists.

### Solution
The simple solution here is to check if the file exists before attempting to read from it, and fall back to empty string as the index content if the file does not exist.

### Further thoughts
On the [issue](https://github.com/esdoc/esdoc/issues/432) there are [reports](https://github.com/esdoc/esdoc/issues/432#issuecomment-322345001) of esdoc also crashing if a readme is present at the top level of the project but its not named exactly `README.md`, which may frequently be the case on case sensitive file systems. This PR does not remedy that scenario by reading the correct file but it will at least allow esdoc to run without crashing. It is up to the user then to find the correct configuration option from the `ESDoc Config` table here: https://github.com/esdoc/esdoc-site/blob/master/src/manual/config.md

### Outcome
Resolves https://github.com/esdoc/esdoc/issues/432 and duplicate https://github.com/esdoc/esdoc/issues/484.