### PR TITLE
Updated 'marked' to address the security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "esdoc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -619,7 +619,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
     },
     "balanced-match": {
       "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -1197,26 +1197,15 @@
       }
     },
     "esdoc-accessor-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-accessor-plugin/-/esdoc-accessor-plugin-0.0.5.tgz",
-      "integrity": "sha1-efZjc0a4uenpnGPsZTOTB6orAG0=",
-      "dev": true
-    },
-    "esdoc-brand-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-brand-plugin/-/esdoc-brand-plugin-0.0.7.tgz",
-      "integrity": "sha1-DkEA+XgwL0LN79QYeBMBUYsIr2E=",
-      "dev": true,
-      "requires": {
-        "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz"
-      }
-    },
-    "esdoc-coverage-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-coverage-plugin/-/esdoc-coverage-plugin-0.0.5.tgz",
-      "integrity": "sha1-SfGd7/C18Gh+mzDJSR5Jsge851A=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-accessor-plugin/-/esdoc-accessor-plugin-1.0.0.tgz",
+      "integrity": "sha1-eRukhy5sQDUVznSbE0jW8Ck62es=",
       "dev": true
     },
     "esdoc-external-ecmascript-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-external-ecmascript-plugin/-/esdoc-external-ecmascript-plugin-0.0.5.tgz",
-      "integrity": "sha1-dtIeOsBE4qw47vgpViyCOEPGbYc=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-external-ecmascript-plugin/-/esdoc-external-ecmascript-plugin-1.0.0.tgz",
+      "integrity": "sha1-ePVl1KDFGFrGMVJhTc4f4ahmiNs=",
       "dev": true,
       "requires": {
         "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz"
@@ -1227,33 +1216,23 @@
       "integrity": "sha1-q3BDMmio8tjfEvtI6uBatFeZVAY=",
       "dev": true
     },
-    "esdoc-integrate-manual-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-integrate-manual-plugin/-/esdoc-integrate-manual-plugin-0.0.4.tgz",
-      "integrity": "sha1-NNHXQMCgalh6HBwLm5BdWA/Bhbo=",
-      "dev": true
-    },
-    "esdoc-integrate-test-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-integrate-test-plugin/-/esdoc-integrate-test-plugin-0.0.4.tgz",
-      "integrity": "sha1-CsIdZPkOUKifj2wXGYYYKG7HUmk=",
-      "dev": true
-    },
-    "esdoc-lint-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-lint-plugin/-/esdoc-lint-plugin-0.0.4.tgz",
-      "integrity": "sha1-M6ZMCz89NVpoV5ZUEVMhz37Ar2g=",
-      "dev": true
-    },
-    "esdoc-publish-html-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-publish-html-plugin/-/esdoc-publish-html-plugin-0.0.12.tgz",
-      "integrity": "sha1-seLcFMEu1oFXtsd6Ab+7qyTeDeo=",
+    "esdoc-standard-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-standard-plugin/-/esdoc-standard-plugin-1.0.0.tgz",
+      "integrity": "sha1-ZhIBysfvhokkkCRG/awVJyU8XU0=",
       "dev": true,
       "requires": {
-        "babel-generator": "6.11.4",
-        "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-        "ice-cap": "https://registry.npmjs.org/ice-cap/-/ice-cap-0.0.4.tgz",
-        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-        "taffydb": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.2.tgz"
+        "esdoc-accessor-plugin": "1.0.0",
+        "esdoc-brand-plugin": "1.0.0",
+        "esdoc-coverage-plugin": "1.1.0",
+        "esdoc-external-ecmascript-plugin": "1.0.0",
+        "esdoc-integrate-manual-plugin": "1.0.0",
+        "esdoc-integrate-test-plugin": "1.0.0",
+        "esdoc-lint-plugin": "1.0.1",
+        "esdoc-publish-html-plugin": "1.1.0",
+        "esdoc-type-inference-plugin": "1.0.1",
+        "esdoc-undocumented-identifier-plugin": "1.0.0",
+        "esdoc-unexported-identifier-plugin": "1.0.0"
       },
       "dependencies": {
         "babel-generator": {
@@ -1262,13 +1241,50 @@
           "integrity": "sha1-FPaTOrsgxiZm0n47e59bncBxKpo=",
           "dev": true,
           "requires": {
-            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
             "detect-indent": "3.0.1",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            "lodash": "4.17.5",
+            "source-map": "0.5.7"
           }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "lodash": "4.17.5",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+          "dev": true
         },
         "detect-indent": {
           "version": "3.0.1",
@@ -1281,6 +1297,84 @@
             "repeating": "1.1.3"
           }
         },
+        "esdoc-brand-plugin": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/esdoc-brand-plugin/-/esdoc-brand-plugin-1.0.0.tgz",
+          "integrity": "sha1-niFtc15i/OxJ96M5u0Eh2mfMYDM=",
+          "dev": true,
+          "requires": {
+            "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz"
+          }
+        },
+        "esdoc-coverage-plugin": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/esdoc-coverage-plugin/-/esdoc-coverage-plugin-1.1.0.tgz",
+          "integrity": "sha1-OGmGnNf4eJH5cmJXh2laKZrs5Fw=",
+          "dev": true
+        },
+        "esdoc-integrate-manual-plugin": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/esdoc-integrate-manual-plugin/-/esdoc-integrate-manual-plugin-1.0.0.tgz",
+          "integrity": "sha1-GFSmqhwIEDXXyMUeO91PtlqkcRw=",
+          "dev": true
+        },
+        "esdoc-integrate-test-plugin": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/esdoc-integrate-test-plugin/-/esdoc-integrate-test-plugin-1.0.0.tgz",
+          "integrity": "sha1-4tDQAJD38MNeXS8sAzMnp55T5Ak=",
+          "dev": true
+        },
+        "esdoc-lint-plugin": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/esdoc-lint-plugin/-/esdoc-lint-plugin-1.0.1.tgz",
+          "integrity": "sha1-h77mQD5nbAh/Yb6SxFLWDyxqcOU=",
+          "dev": true
+        },
+        "esdoc-publish-html-plugin": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/esdoc-publish-html-plugin/-/esdoc-publish-html-plugin-1.1.0.tgz",
+          "integrity": "sha1-CT+DN6yhaQIlcss4f/zD9HCwJRM=",
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.11.4",
+            "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+            "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+            "ice-cap": "https://registry.npmjs.org/ice-cap/-/ice-cap-0.0.4.tgz",
+            "marked": "0.3.6",
+            "taffydb": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.2.tgz"
+          }
+        },
+        "esdoc-type-inference-plugin": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/esdoc-type-inference-plugin/-/esdoc-type-inference-plugin-1.0.1.tgz",
+          "integrity": "sha1-qrynhkH5m9Hs5vMC8EW71jG+cvU=",
+          "dev": true
+        },
+        "esdoc-unexported-identifier-plugin": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/esdoc-unexported-identifier-plugin/-/esdoc-unexported-identifier-plugin-1.0.0.tgz",
+          "integrity": "sha1-H5h0xqfCvr+a05fDzrdcnGnaurE=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "marked": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+          "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        },
         "repeating": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
@@ -1289,40 +1383,25 @@
           "requires": {
             "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
           }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
         }
       }
     },
-    "esdoc-standard-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-standard-plugin/-/esdoc-standard-plugin-0.0.8.tgz",
-      "integrity": "sha1-JolaBzj/XWlFYzKQ6cABrMR1RYc=",
-      "dev": true,
-      "requires": {
-        "esdoc-accessor-plugin": "https://registry.npmjs.org/esdoc-accessor-plugin/-/esdoc-accessor-plugin-0.0.5.tgz",
-        "esdoc-brand-plugin": "https://registry.npmjs.org/esdoc-brand-plugin/-/esdoc-brand-plugin-0.0.7.tgz",
-        "esdoc-coverage-plugin": "https://registry.npmjs.org/esdoc-coverage-plugin/-/esdoc-coverage-plugin-0.0.5.tgz",
-        "esdoc-external-ecmascript-plugin": "https://registry.npmjs.org/esdoc-external-ecmascript-plugin/-/esdoc-external-ecmascript-plugin-0.0.5.tgz",
-        "esdoc-integrate-manual-plugin": "https://registry.npmjs.org/esdoc-integrate-manual-plugin/-/esdoc-integrate-manual-plugin-0.0.4.tgz",
-        "esdoc-integrate-test-plugin": "https://registry.npmjs.org/esdoc-integrate-test-plugin/-/esdoc-integrate-test-plugin-0.0.4.tgz",
-        "esdoc-lint-plugin": "https://registry.npmjs.org/esdoc-lint-plugin/-/esdoc-lint-plugin-0.0.4.tgz",
-        "esdoc-publish-html-plugin": "https://registry.npmjs.org/esdoc-publish-html-plugin/-/esdoc-publish-html-plugin-0.0.12.tgz",
-        "esdoc-type-inference-plugin": "https://registry.npmjs.org/esdoc-type-inference-plugin/-/esdoc-type-inference-plugin-0.0.3.tgz",
-        "esdoc-undocumented-identifier-plugin": "https://registry.npmjs.org/esdoc-undocumented-identifier-plugin/-/esdoc-undocumented-identifier-plugin-0.0.6.tgz",
-        "esdoc-unexported-identifier-plugin": "https://registry.npmjs.org/esdoc-unexported-identifier-plugin/-/esdoc-unexported-identifier-plugin-0.0.5.tgz"
-      }
-    },
-    "esdoc-type-inference-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-type-inference-plugin/-/esdoc-type-inference-plugin-0.0.3.tgz",
-      "integrity": "sha1-5TsQ3A96VQl/XzMtz5+DX0xy1nk=",
-      "dev": true
-    },
     "esdoc-undocumented-identifier-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-undocumented-identifier-plugin/-/esdoc-undocumented-identifier-plugin-0.0.6.tgz",
-      "integrity": "sha1-2VzRynR5WkNbMnXBOsMnqTR91pM=",
-      "dev": true
-    },
-    "esdoc-unexported-identifier-plugin": {
-      "version": "https://registry.npmjs.org/esdoc-unexported-identifier-plugin/-/esdoc-unexported-identifier-plugin-0.0.5.tgz",
-      "integrity": "sha1-5jzTPMetGMCYNDST2RNyVoAVbsQ=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-undocumented-identifier-plugin/-/esdoc-undocumented-identifier-plugin-1.0.0.tgz",
+      "integrity": "sha1-guBdNxwy0ShxFA8dXIHsmf2cwsg=",
       "dev": true
     },
     "eslint": {
@@ -2436,11 +2515,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
           "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
@@ -2450,6 +2524,11 @@
             "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
           }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "stringstream": {
           "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -2625,7 +2704,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
     },
     "globby": {
       "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
@@ -3363,8 +3442,9 @@
       "dev": true
     },
     "marked": {
-      "version": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
     },
     "meow": {
       "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -5484,10 +5564,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -5497,6 +5573,10 @@
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
       }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-traverse": "6.26.0",
     "fs-extra": "1.0.0",
     "ice-cap": "0.0.4",
-    "marked": "0.3.6",
+    "marked": "0.3.12",
     "minimist": "1.2.0",
     "taffydb": "2.7.2"
   },


### PR DESCRIPTION
Closes #492, #495, esdoc/esdoc-plugins#50

The local build (`npm test`) is still passing with this change.

**Update**: This PR brings the `marked` dependency to a newer version than #496, but either one will get rid of the security issues.