### PR TITLE
Updated "Marked" npm module from 0.3.19 to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-traverse": "6.26.0",
     "fs-extra": "5.0.0",
     "ice-cap": "0.0.4",
-    "marked": "0.3.19",
+    "marked": "0.7.0",
     "minimist": "1.2.0",
     "taffydb": "2.7.3"
   },


### PR DESCRIPTION
As it is still using the older version of "Marked" module that is creating vulnerability. So updated to the stable version of the "marked" module. kindly verify and merge.

Thanks,
Nikunj Agarwal