### PR TITLE
docs: Fix simple typo, undocument -> undocumented

### DIFF
--- a/manual/config.md
+++ b/manual/config.md
@@ -144,7 +144,7 @@ describe('MyClass has foo bar feature', ()=>{
 | ``coverage.enable`` | - | ``true`` | If true, output document coverage. |
 | ``accessor.access`` | - | ``["public", "protected", "package", "private"]`` | Process only identifiers(class, method, etc...) that are have the access(public, protected, package, and private). |
 | ``accessor.autoPrivate`` | - | ``true`` | Deal with identifiers beginning with "_" as a private. <br> e.g. ``this._foo`` is private. but ``/** @public */ this._foo`` is public.|
-| ``undocumentIdentifier.enable`` | - | ``true`` | If true, also process undocument Identifiers. <br> e.g. ``/** @foo bar */ class MyClass`` is document identifier, ``class MyClass`` is undocument identifier. |
+| ``undocumentIdentifier.enable`` | - | ``true`` | If true, also process undocumented Identifiers. <br> e.g. ``/** @foo bar */ class MyClass`` is document identifier, ``class MyClass`` is undocumented identifier. |
 | ``unexportedIdentifier.enable`` | - | ``false`` | If true, also process unexported Identifiers. <br> e.g. ``export class MyClass`` is exported, ``class MyClass`` is not exported. |
 | `typeInference.true` | - | `true` | If true, infer type of variable, return value. |
 | `brand.logo` | - | - | aaa |


### PR DESCRIPTION
There is a small typo in manual/config.md.

Should read `undocumented` rather than `undocument`.

